### PR TITLE
[Fix] Tuple::compare use strcmp instead of spaceship operator (#53)

### DIFF
--- a/src/Tuple/Tuple.php
+++ b/src/Tuple/Tuple.php
@@ -122,7 +122,7 @@ final class Tuple
         $packed1 = self::pack($tuple1);
         $packed2 = self::pack($tuple2);
 
-        return $packed1 <=> $packed2;
+        return strcmp($packed1, $packed2) <=> 0;
     }
 
     /**

--- a/tests/Unit/Tuple/TupleCompareTest.php
+++ b/tests/Unit/Tuple/TupleCompareTest.php
@@ -300,6 +300,28 @@ final class TupleCompareTest extends TestCase
     }
 
     #[Test]
+    public function compareNumericLookingStrings(): void
+    {
+        // Packed bytes that look like numeric strings must NOT be coerced by PHP's <=>
+        // strcmp() compares byte-by-byte, preserving correct ordering.
+        // These bytes happen to form numeric-like strings when interpreted as ASCII.
+        $a = "\x31\x32\x33"; // "123"
+        $b = "\x32\x31\x30"; // "210"
+
+        // Pack them as Bytes to preserve raw bytes, then compare
+        $result = Tuple::compare([new Bytes($a)], [new Bytes($b)]);
+        self::assertSame(-1, $result);
+
+        // Also test strings that might look numeric
+        $result2 = Tuple::compare(["123"], ["210"]);
+        self::assertSame(-1, $result2);
+
+        // Test equality for same numeric-looking string
+        $result3 = Tuple::compare(["123"], ["123"]);
+        self::assertSame(0, $result3);
+    }
+
+    #[Test]
     public function compareMatchesPackedByteOrdering(): void
     {
         $pairs = [


### PR DESCRIPTION
## Summary

Fixes #53.

Replace the spaceship operator (`$packed1 <=> $packed2`) with `strcmp($packed1, $packed2) <=> 0` for byte-wise comparison of packed tuple data. PHP's `<=>` can coerce numeric-looking strings (numeric-string coercion), which is a latent correctness footgun. `strcmp()` compares byte-by-byte and the result is normalized to -1/0/1.

## Changes

- **src/Tuple/Tuple.php:125** — Changed `return $packed1 <=> $packed2` to `return strcmp($packed1, $packed2) <=> 0`
- **tests/Unit/Tuple/TupleCompareTest.php** — Added `compareNumericLookingStrings()` test that verifies correct ordering of bytes that look like numeric strings, plus equality and regular string ordering

## Verification

- All 318 unit tests pass (including all 45 tuple comparison tests)
- Code style (PHPCS) passes
- No new PHPStan errors

## Acceptance Criteria

- [x] Unit test(s) added covering ordering of values whose packed form is numeric-looking, plus general ordering
- [x] Functional test(s) covered by existing tuple-ordering tests (all pass)
- [x] Changelog entry — no CHANGELOG file exists in the project
