### PR TITLE
fix: AdminClient::getClusterStatus validate json_decode result (#44)

### DIFF
--- a/src/AdminClient.php
+++ b/src/AdminClient.php
@@ -220,9 +220,30 @@ final readonly class AdminClient
             throw new \RuntimeException('Failed to retrieve cluster status');
         }
 
-        /** @var array<string, mixed> $data */
-        $data = json_decode($json, true);
+        return $this->decodeClusterStatusJson($json);
+    }
 
+    /**
+     * Decode and validate cluster status JSON.
+     *
+     * @param string $json Raw JSON string from the cluster status special key
+     *
+     * @return array<string, mixed>
+     *
+     * @throws \JsonException  If the JSON is syntactically invalid
+     * @throws \RuntimeException If the decoded value is not an object (associative array)
+     *
+     * @internal
+     */
+    private function decodeClusterStatusJson(string $json): array
+    {
+        $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($data)) {
+            throw new \RuntimeException('Cluster status response is not a valid JSON object');
+        }
+
+        /** @var array<string, mixed> $data */
         return $data;
     }
 

--- a/tests/Unit/AdminClientTest.php
+++ b/tests/Unit/AdminClientTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\FoundationDB\Tests\Unit;
+
+use CrazyGoat\FoundationDB\AdminClient;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AdminClientTest extends TestCase
+{
+    /**
+     * Call private AdminClient::decodeClusterStatusJson via reflection.
+     *
+     * @param string $json Raw JSON string
+     *
+     * @return mixed
+     */
+    private function decodeClusterStatusJson(string $json): mixed
+    {
+        $method = new \ReflectionMethod(AdminClient::class, 'decodeClusterStatusJson');
+        $admin = $this->createAdminClient();
+
+        return $method->invoke($admin, $json);
+    }
+
+    /**
+     * Create a minimal AdminClient instance without constructor using reflection.
+     */
+    private function createAdminClient(): AdminClient
+    {
+        $reflection = new \ReflectionClass(AdminClient::class);
+        /** @var AdminClient $instance */
+        $instance = $reflection->newInstanceWithoutConstructor();
+
+        return $instance;
+    }
+
+    // -- decodeClusterStatusJson unit tests -----------------------------------
+
+    #[Test]
+    public function decodeValidJsonObject(): void
+    {
+        $result = $this->decodeClusterStatusJson('{"key": "value"}');
+
+        self::assertSame(['key' => 'value'], $result);
+    }
+
+    #[Test]
+    public function decodeValidJsonWithNestedData(): void
+    {
+        $result = $this->decodeClusterStatusJson('{"cluster": {"name": "test", "healthy": true}}');
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('cluster', $result);
+        self::assertIsArray($result['cluster']);
+        self::assertSame('test', $result['cluster']['name']);
+        self::assertTrue($result['cluster']['healthy']);
+    }
+
+    #[Test]
+    public function decodeThrowsOnNullLiteral(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('not a valid JSON object');
+
+        $this->decodeClusterStatusJson('null');
+    }
+
+    #[Test]
+    public function decodeThrowsOnNumber(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('not a valid JSON object');
+
+        $this->decodeClusterStatusJson('42');
+    }
+
+    #[Test]
+    public function decodeThrowsOnString(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('not a valid JSON object');
+
+        $this->decodeClusterStatusJson('"just a string"');
+    }
+
+    #[Test]
+    public function decodeThrowsOnBoolean(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('not a valid JSON object');
+
+        $this->decodeClusterStatusJson('true');
+    }
+
+    #[Test]
+    public function decodeThrowsJsonExceptionOnSyntaxError(): void
+    {
+        $this->expectException(\JsonException::class);
+
+        $this->decodeClusterStatusJson('{"broken":}');
+    }
+
+    #[Test]
+    public function decodeThrowsJsonExceptionOnTruncatedJson(): void
+    {
+        $this->expectException(\JsonException::class);
+
+        $this->decodeClusterStatusJson('{"key"');
+    }
+}

--- a/tests/Unit/AdminClientTest.php
+++ b/tests/Unit/AdminClientTest.php
@@ -14,8 +14,6 @@ final class AdminClientTest extends TestCase
      * Call private AdminClient::decodeClusterStatusJson via reflection.
      *
      * @param string $json Raw JSON string
-     *
-     * @return mixed
      */
     private function decodeClusterStatusJson(string $json): mixed
     {


### PR DESCRIPTION
## Summary

Fixes #44

Added proper validation for `json_decode()` result in `AdminClient::getClusterStatus()`:

- Added `JSON_THROW_ON_ERROR` flag to catch malformed JSON
- Added `is_array()` check on decoded value, throwing `RuntimeException` for non-object results
- Extracted decode-and-validate logic into private method for testability
- Added 8 unit tests covering all edge cases

### Testing
- `composer test:unit` — all 326 tests pass (8 new + 318 existing)
- `composer lint` — passes (only pre-existing Tuple.php PHPStan errors)