### PR TITLE
fix: RangeResult limit=0 returns empty result instead of ambiguous batch (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+- [#51] RangeResult: `limit: 0` now correctly returns an empty result instead of one full batch.
+  Previously, passing `limit: 0` to `RangeOptions` was equivalent to "unlimited" for the first
+  batch and then stopped immediately, producing an ambiguous single-batch result. `limit: 0` is
+  now explicitly treated as "no rows" (empty iterator), while `limit: null` remains the way to
+  request all matching rows.

--- a/docs/range-reads.md
+++ b/docs/range-reads.md
@@ -64,7 +64,7 @@ use CrazyGoat\FoundationDB\RangeOptions;
 use CrazyGoat\FoundationDB\Enum\StreamingMode;
 
 $options = new RangeOptions(
-    limit: 100,           // max results (null = unlimited)
+    limit: 100,           // max results (null = unlimited, 0 = empty result)
     reverse: true,        // reverse order
     mode: StreamingMode::WantAll,  // streaming mode
 );

--- a/src/RangeOptions.php
+++ b/src/RangeOptions.php
@@ -8,6 +8,14 @@ use CrazyGoat\FoundationDB\Enum\StreamingMode;
 
 final readonly class RangeOptions
 {
+    /**
+     * @param ?int $limit Maximum number of rows to return.
+     *                     - null: unlimited (all matching rows)
+     *                     - 0:    no rows (empty result)
+     *                     - >0:   at most N rows
+     * @param bool $reverse If true, results are returned in reverse key order.
+     * @param StreamingMode $mode Controls server-side batch sizing strategy.
+     */
     public function __construct(
         public ?int $limit = null,
         public bool $reverse = false,

--- a/src/RangeResult.php
+++ b/src/RangeResult.php
@@ -33,6 +33,11 @@ final readonly class RangeResult implements \IteratorAggregate
         $iteration = 1;
         $fetched = 0;
 
+        // A limit of 0 means "no rows" — return immediately.
+        if ($limit === 0) {
+            return;
+        }
+
         while (true) {
             $currentLimit = $limit !== null ? $limit - $fetched : 0;
 

--- a/tests/Integration/RangeReadTest.php
+++ b/tests/Integration/RangeReadTest.php
@@ -146,6 +146,35 @@ final class RangeReadTest extends TestCase
     }
 
     #[Test]
+    public function getRangeWithLimitZeroReturnsEmpty(): void
+    {
+        $this->getDatabase()->set('range_test/a', '1');
+        $this->getDatabase()->set('range_test/b', '2');
+        $this->getDatabase()->set('range_test/c', '3');
+
+        $result = $this->getDatabase()->getRangeStartsWith(
+            'range_test/',
+            new RangeOptions(limit: 0),
+        );
+
+        self::assertCount(0, $result);
+    }
+
+    #[Test]
+    public function getRangeAllWithLimitZeroReturnsEmpty(): void
+    {
+        $this->getDatabase()->set('range_test/a', '1');
+        $this->getDatabase()->set('range_test/b', '2');
+
+        $result = $this->getDatabase()->getRangeAllStartsWith(
+            'range_test/',
+            new RangeOptions(limit: 0),
+        );
+
+        self::assertCount(0, $result);
+    }
+
+    #[Test]
     public function getRangeReturnsRangeResultFromTransaction(): void
     {
         $this->getDatabase()->set('range_test/a', '1');


### PR DESCRIPTION
Closes #51

**Problem:** `RangeResult` treated `limit: 0` as "unlimited" for the first batch (because FoundationDB C API interprets 0 as unlimited), then broke immediately because `fetched (0) >= limit (0)`. This produced an ambiguous single-batch result.

**Fix:** Added an early return in `getIterator()` when `$limit === 0`, so the generator yields zero rows immediately. `limit: null` remains the way to request all matching rows.

**Tests added:**
- `getRangeWithLimitZeroReturnsEmpty` — integration test verifying limit=0 returns empty
- `getRangeAllWithLimitZeroReturnsEmpty` — same for eager fetch

All 326 unit tests pass.