### PR TITLE
fix: FutureStringArray::await() returns dangling CData instead of owned PHP strings (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Fixed
+- [#36] FutureStringArray: `await()` now copies `char*` elements into owned PHP strings via
+  `FFI::string()` before releasing the future's memory. Previously, the method returned raw
+  `FFI\CData` pointers that became dangling after `releaseMemory()`, causing use-after-free in
+  `getAddressesForKey()` and any other consumer.
 - [#51] RangeResult: `limit: 0` now correctly returns an empty result instead of one full batch.
   Previously, passing `limit: 0` to `RangeOptions` was equivalent to "unlimited" for the first
   batch and then stopped immediately, producing an ambiguous single-batch result. `limit: 0` is

--- a/src/Future/FutureStringArray.php
+++ b/src/Future/FutureStringArray.php
@@ -37,9 +37,7 @@ final class FutureStringArray extends Future
         $strings = [];
 
         for ($i = 0; $i < $count; $i++) {
-            /** @var string $str */
-            $str = $outStrings[$i];
-            $strings[] = $str;
+            $strings[] = FFI::string($outStrings[$i]);
         }
 
         $this->cachedResult = $strings;

--- a/tests/Integration/BasicCrudTest.php
+++ b/tests/Integration/BasicCrudTest.php
@@ -151,5 +151,10 @@ final class BasicCrudTest extends TestCase
         $addresses = $tr->getAddressesForKey('test/addresses')->await();
 
         self::assertNotEmpty($addresses);
+        foreach ($addresses as $address) {
+            /** @phpstan-ignore staticMethod.alreadyNarrowedType (runtime guard against CData regression) */
+            self::assertIsString($address);
+            self::assertMatchesRegularExpression('/^.+:\d+$/', $address);
+        }
     }
 }


### PR DESCRIPTION
## Problem

`FutureStringArray::await()` indexes `char**` directly (`[]`), which returns an `FFI\CData` pointer — not a PHP string. After `releaseMemory()` those pointers become dangling (use-after-free). This is the public path behind `ReadTransaction::getAddressesForKey()`.

## Fix

Replaced raw `char*` indexing with `FFI::string()` to copy each element into an owned PHP string before the future's memory is released — same pattern already used in `FutureKeyArray::await()`.

## Changes

| File | Change |
|------|--------|
| `src/Future/FutureStringArray.php` | `FFI::string([])` instead of raw pointer assignment |
| `tests/Integration/BasicCrudTest.php` | `getAddressesForKey()` test now verifies elements are real strings matching `host:port` format |
| `CHANGELOG.md` | Entry added |

## Verification

- ✅ PHPStan level 9 — 0 new errors
- ✅ Integration tests require FoundationDB cluster (CI will validate)

Closes #36