### PR TITLE
fix: configure PHPStan --memory-limit=512M (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Fixed
+- [#56] PHPStan: configure `--memory-limit=512M` in the `phpstan` composer script to prevent
+  analysis from crashing under the default 128M limit on large codebases.
 - [#36] FutureStringArray: `await()` now copies `char*` elements into owned PHP strings via
   `FFI::string()` before releasing the future's memory. Previously, the method returned raw
   `FFI\CData` pointers that became dangling after `releaseMemory()`, causing use-after-free in

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "scripts": {
         "lint": ["phpcs --standard=phpcs.xml.dist", "@rector", "@phpstan"],
         "lint:fix": ["@rector:fix", "phpcbf --standard=phpcs.xml.dist"],
-        "phpstan": "phpstan analyse",
+        "phpstan": "phpstan analyse --memory-limit=512M",
         "cs": "phpcs --standard=phpcs.xml.dist",
         "cs-fix": "phpcbf --standard=phpcs.xml.dist",
         "test": "phpunit",


### PR DESCRIPTION
## Problem

PHPStan crashes under the default 128M memory limit when analysing the codebase, causing 
 [OK] No errors                                                                  (and CI) to fail silently or incompletely.

The4  argument.type errors mentioned in #56 were already fixed in PR #62 ( bitmask on lines 215, 244, 313, 759 of ). This PR addresses the remaining memory limit issue.

## Changes

- **composer.json**: Add  to the  composer script
- **CHANGELOG.md**: Add entry for #56

## Verification

- ............................................................ 60 / 73 (82%)
.............                                                73 / 73 (100%)


Time: 468ms; Memory: 20MB



 [OK] Rector is done!                                                           


 [OK] No errors                                                                  passes (PHPCS + Rector + PHPStan level 9, 0 errors)
- PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.7
Configuration: /Users/piotr.halas/work/fdb-php/phpunit.xml

...............................................................  63 / 326 ( 19%)
............................................................... 126 / 326 ( 38%)
............................................................... 189 / 326 ( 57%)
............................................................... 252 / 326 ( 77%)
............................................................... 315 / 326 ( 96%)
...........                                                     326 / 326 (100%)

Time: 00:00.064, Memory: 10.00 MB

OK (326 tests, 593 assertions) passes (326 tests, 593 assertions)

Closes #56