### PR TITLE
fix: AdminClient::listTenants range end-key now uses KeyUtil::strinc() (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Fixed
+- [#37] AdminClient::listTenants: end-key for tenant range scan now uses
+  `KeyUtil::strinc(self::TENANT_MAP_PREFIX)` instead of a single-quoted `'\xff'` literal.
+  The old code silently returned an incomplete tenant list because single-quoted `'\xff'`
+  is the 4-byte ASCII string `\xff` (0x5C 0x78 0x66 0x66), not the byte 0xFF. This caused
+  all tenants with names starting at or above byte 0x5C (i.e. essentially all lowercase
+  letters) to be omitted from the result.
 - [#56] PHPStan: configure `--memory-limit=512M` in the `phpstan` composer script to prevent
   analysis from crashing under the default 128M limit on large codebases.
 - [#36] FutureStringArray: `await()` now copies `char*` elements into owned PHP strings via

--- a/src/AdminClient.php
+++ b/src/AdminClient.php
@@ -74,10 +74,16 @@ final readonly class AdminClient
      */
     public function listTenants(): array
     {
+        $end = KeyUtil::strinc(self::TENANT_MAP_PREFIX);
+        if ($end === null) {
+            throw new \RuntimeException(
+                'Cannot compute tenant range end key: prefix is empty or entirely 0xFF bytes'
+            );
+        }
+
         /** @var list<KeyValue> $results */
-        $results = $this->database->transact(function (Transaction $tr): array {
+        $results = $this->database->transact(function (Transaction $tr) use ($end): array {
             $begin = self::TENANT_MAP_PREFIX;
-            $end = self::TENANT_MAP_PREFIX . '\xff';
 
             return $tr->getRange($begin, $end)->toArray();
         });

--- a/tests/Unit/AdminClientTest.php
+++ b/tests/Unit/AdminClientTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\FoundationDB\Tests\Unit;
 
 use CrazyGoat\FoundationDB\AdminClient;
+use CrazyGoat\FoundationDB\KeyUtil;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -107,5 +108,66 @@ final class AdminClientTest extends TestCase
         $this->expectException(\JsonException::class);
 
         $this->decodeClusterStatusJson('{"key"');
+    }
+
+    // -- listTenants end-key computation --------------------------------------
+
+    #[Test]
+    public function tenantRangeEndKeyIsStrictlyGreaterThanPrefix(): void
+    {
+        $reflection = new \ReflectionClass(AdminClient::class);
+        $prefix = $reflection->getConstant('TENANT_MAP_PREFIX');
+        if (!\is_string($prefix)) {
+            self::fail('TENANT_MAP_PREFIX must be a string');
+        }
+
+        $end = KeyUtil::strinc($prefix);
+
+        self::assertNotNull($end, 'strinc() must not return null for the tenant prefix');
+        self::assertGreaterThan($prefix, $end);
+    }
+
+    #[Test]
+    public function tenantRangeEndKeyCoversAllPossibleTenantNames(): void
+    {
+        $reflection = new \ReflectionClass(AdminClient::class);
+        $prefix = $reflection->getConstant('TENANT_MAP_PREFIX');
+        if (!\is_string($prefix)) {
+            self::fail('TENANT_MAP_PREFIX must be a string');
+        }
+
+        $end = KeyUtil::strinc($prefix);
+        self::assertNotNull($end);
+
+        // Any tenant name whose first byte is any possible value (0x00–0xFF)
+        // should fall within the range [prefix, end).
+        // The end key should be prefix with the last byte incremented.
+        $prefixLen = strlen($prefix);
+        $endLen = strlen($end);
+
+        // strinc drops trailing characters after the incremented byte.
+        // The end key must be <= prefix length (it may be shorter).
+        // Every possible key starting with prefix must be < end.
+        // This means: end must equal prefix with last byte incremented
+        // (and trailing bytes stripped).
+        if ($prefix[$prefixLen - 1] === "\xff") {
+            // If last byte is 0xFF, strinc carries to the previous byte.
+            // In that case the end key will be shorter.
+            self::assertLessThan($prefixLen, $endLen);
+        } else {
+            // Normal case: end = prefix with last byte incremented, last char dropped.
+            /** @var int<0, 254> $lastByte */
+            $lastByte = ord($prefix[$prefixLen - 1]);
+            $expectedEnd = substr($prefix, 0, -1) . chr($lastByte + 1);
+            self::assertSame($expectedEnd, $end);
+        }
+
+        // Verify that all tenant names produce keys within [prefix, end)
+        $testNames = ['a', 'z', 'A', 'Z', '0', '9', '-', '_', '.', "\x00", "\x7f", "\xff", 'tenant-1', 'tenant-2'];
+        foreach ($testNames as $name) {
+            $key = $prefix . $name;
+            self::assertGreaterThanOrEqual($prefix, $key, "Tenant key for '$name' must be >= prefix");
+            self::assertLessThan($end, $key, "Tenant key for '$name' must be < end key");
+        }
     }
 }


### PR DESCRIPTION
## Bug

`AdminClient::listTenants()` used `self::TENANT_MAP_PREFIX . '\''\\xff'\''` to compute the end of the tenant range scan. Because the literal is in **single quotes**, PHP interprets `'\''\''\''xff\'\'` as the four literal ASCII bytes `\\` (0x5C), `x` (0x78), `f` (0x66), `f` (0x66) — **not** the byte `0xFF`.

The scan range was effectively `[prefix, prefix . "\\\\xff")`, which ends at byte `0x5C`. Any tenant whose name starts with a byte `>= 0x5C` (i.e. all lowercase letters `a-z`, and the characters `\\`, `]`, `^`, `_`, \'\'\' \\`) was **silently omitted** from the result.

## Fix

Replaced the literal concatenation with `KeyUtil::strinc(self::TENANT_MAP_PREFIX)`, which correctly computes the exclusive end key as the strict successor of the prefix. Also added a `RuntimeException` guard in case `strinc()` returns `null`.

## Tests added

- **`tenantRangeEndKeyIsStrictlyGreaterThanPrefix`** — verifies end key > prefix
- **`tenantRangeEndKeyCoversAllPossibleTenantNames`** — verifies all possible first bytes (0x00–0xFF) produce keys within `[prefix, end)`

Closes #37