### PR TITLE
fix(#39): enforce tuple nesting depth explicitly with MAX_NESTING_DEPTH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,21 @@
   truncating to the first 8 bytes via `unpack('P')`. The previous behavior could return
   a wrong integer value if the stored value was malformed or larger than the 8-byte
   little-endian integer contract.
+- [#39] `Tuple::unpack()` and the encode side now reject
+  deeply-nested inputs at a fixed, public bound
+  (`Tuple::MAX_NESTING_DEPTH`, currently `100`) instead of
+  recursing without limit. Previously, a stored value made up
+  entirely of `\x05` TYPE_NESTED bytes (the issue's PoC was
+  hundreds of kilobytes) would exhaust the call stack and abort
+  the process whenever an application called `unpack()` /
+  `Subspace::unpack()` on data produced by a less-trusted writer.
+  The bound is enforced symmetrically on
+  `Tuple::pack()`, `Tuple::unpack()`,
+  `Tuple::packWithVersionstamp()`,
+  `Tuple::hasIncompleteVersionstamp()`, and on the encode-side
+  helpers `findVersionstampOffset` and `countVersionstamps`. Any
+  payload whose deepest recursion step would exceed
+  `MAX_NESTING_DEPTH` raises
+  `\InvalidArgumentException` immediately at the offending call;
+  wire bytes that round-trip just at the limit are still accepted,
+  so legitimate deeply-nested user data is unaffected.

--- a/docs/tuple-layer.md
+++ b/docs/tuple-layer.md
@@ -112,3 +112,15 @@ $vs->isComplete(); // true
 ## Cross-Language Compatibility
 
 The encoding is binary-compatible with official FDB tuple layers in Python, Go, Java, and Ruby.
+
+## Nesting Depth Limit
+
+The encoder and decoder share a single hard cap on nested-tuple depth to protect the host process from denial-of-service inputs. The threshold is exposed as `Tuple::MAX_NESTING_DEPTH` (currently `100`):
+
+```php
+use CrazyGoat\FoundationDB\Tuple\Tuple;
+
+echo Tuple::MAX_NESTING_DEPTH; // 100
+```
+
+A payload that would recurse past `MAX_NESTING_DEPTH` levels (for example, a stored value consisting of hundreds of kilobytes of `\x05` TYPE_NESTED bytes) raises `\InvalidArgumentException` immediately at the offending call, instead of consuming the call stack until the process aborts. The guard fires symmetrically on the encode and decode paths — `pack()`, `unpack()`, `packWithVersionstamp()` and `hasIncompleteVersionstamp()` all honour the same constant, and the encode-side helpers `findVersionstampOffset` and `countVersionstamps` apply it while walking deeply-nested PHP arrays.

--- a/src/Tuple/Tuple.php
+++ b/src/Tuple/Tuple.php
@@ -6,6 +6,17 @@ namespace CrazyGoat\FoundationDB\Tuple;
 
 final class Tuple
 {
+    /**
+     * The deepest array-nesting level that {@see \CrazyGoat\FoundationDB\Tuple\Tuple}
+     * will tolerate in either pack() or unpack(). Nested arrays beyond this
+     * depth cause an {@see \InvalidArgumentException} to be raised at the
+     * encoded recursion site instead of consuming the call stack. The
+     * threshold is deliberately inclusive: a payload whose deepest recursion
+     * peak equals {@see Tuple::MAX_NESTING_DEPTH} is accepted, while
+     * {@see Tuple::MAX_NESTING_DEPTH}+1 is rejected.
+     */
+    public const MAX_NESTING_DEPTH = 100;
+
     private const TYPE_NULL = 0x00;
     private const TYPE_BYTES = 0x01;
     private const TYPE_STRING = 0x02;
@@ -30,7 +41,7 @@ final class Tuple
         $result = $prefix;
 
         foreach ($elements as $element) {
-            $result .= self::encodeElement($element, false);
+            $result .= self::encodeElement($element, false, 0);
         }
 
         return $result;
@@ -46,7 +57,7 @@ final class Tuple
         $versionstampCount = 0;
 
         foreach ($elements as $element) {
-            self::countVersionstamps($element, $versionstampCount);
+            self::countVersionstamps($element, $versionstampCount, 0);
         }
 
         if ($versionstampCount === 0) {
@@ -63,12 +74,12 @@ final class Tuple
 
         foreach ($elements as $element) {
             $offset = strlen($result);
-            $encoded = self::encodeElement($element, false);
+            $encoded = self::encodeElement($element, false, 0);
 
             if ($element instanceof Versionstamp) {
                 $versionstampOffset = $offset + 1;
             } elseif (is_array($element)) {
-                $innerOffset = self::findVersionstampOffset($element, $offset + 1);
+                $innerOffset = self::findVersionstampOffset($element, $offset + 1, 0);
                 if ($innerOffset >= 0) {
                     $versionstampOffset = $innerOffset;
                 }
@@ -91,7 +102,7 @@ final class Tuple
         $elements = [];
 
         while ($pos < $length) {
-            [$value, $consumed] = self::decodeElement($data, $pos, $length);
+            [$value, $consumed] = self::decodeElement($data, $pos, $length, 0);
             $elements[] = $value;
             $pos += $consumed;
         }
@@ -105,7 +116,7 @@ final class Tuple
     public static function hasIncompleteVersionstamp(array $elements): bool
     {
         foreach ($elements as $element) {
-            if (self::elementHasIncompleteVersionstamp($element)) {
+            if (self::elementHasIncompleteVersionstamp($element, 0)) {
                 return true;
             }
         }
@@ -136,7 +147,7 @@ final class Tuple
         return [$packed . "\x00", $packed . "\xFF"];
     }
 
-    private static function encodeElement(mixed $element, bool $nested): string
+    private static function encodeElement(mixed $element, bool $nested, int $depth): string
     {
         if ($element === null) {
             return $nested ? "\x00\xFF" : "\x00";
@@ -180,10 +191,23 @@ final class Tuple
 
         if (is_array($element)) {
             /** @var list<mixed> $element */
-            return self::encodeNestedTuple($element);
+            return self::encodeNestedTuple($element, $depth + 1);
         }
 
         throw new \InvalidArgumentException('Unsupported tuple element type: ' . get_debug_type($element));
+    }
+
+    /**
+     * @throws \InvalidArgumentException If `$depth` would recurse past {@see self::MAX_NESTING_DEPTH}.
+     */
+    private static function assertDepth(int $depth): void
+    {
+        if ($depth > self::MAX_NESTING_DEPTH) {
+            throw new \InvalidArgumentException(
+                'Tuple nesting depth exceeds the maximum of ' . self::MAX_NESTING_DEPTH
+                . ' (denial-of-service guard); got depth ' . $depth,
+            );
+        }
     }
 
     private static function encodeBytes(Bytes $bytes): string
@@ -363,12 +387,13 @@ final class Tuple
     /**
      * @param list<mixed> $elements
      */
-    private static function encodeNestedTuple(array $elements): string
+    private static function encodeNestedTuple(array $elements, int $depth): string
     {
+        self::assertDepth($depth);
         $result = chr(self::TYPE_NESTED);
 
         foreach ($elements as $element) {
-            $result .= self::encodeElement($element, true);
+            $result .= self::encodeElement($element, true, $depth);
         }
 
         return $result . "\x00";
@@ -377,7 +402,7 @@ final class Tuple
     /**
      * @return array{null|bool|int|float|string|\GMP|Bytes|SingleFloat|Uuid|Versionstamp|list<mixed>, int}
      */
-    private static function decodeElement(string $data, int $pos, int $length): array
+    private static function decodeElement(string $data, int $pos, int $length, int $depth): array
     {
         if ($pos >= $length) {
             throw new \InvalidArgumentException('Unexpected end of data at position ' . $pos);
@@ -389,7 +414,7 @@ final class Tuple
             $code === self::TYPE_NULL => [null, 1],
             $code === self::TYPE_BYTES => self::decodeBytes($data, $pos, $length),
             $code === self::TYPE_STRING => self::decodeString($data, $pos, $length),
-            $code === self::TYPE_NESTED => self::decodeNestedTuple($data, $pos, $length),
+            $code === self::TYPE_NESTED => self::decodeNestedTuple($data, $pos, $length, $depth + 1),
             $code === self::TYPE_INT_ZERO => [0, 1],
             $code > self::TYPE_INT_ZERO && $code <= self::TYPE_POS_INT_END
                 => self::decodePositiveInt($data, $pos, $length, $code),
@@ -436,8 +461,9 @@ final class Tuple
     /**
      * @return array{list<mixed>, int}
      */
-    private static function decodeNestedTuple(string $data, int $pos, int $length): array
+    private static function decodeNestedTuple(string $data, int $pos, int $length, int $depth): array
     {
+        self::assertDepth($depth);
         $elements = [];
         $innerPos = $pos + 1;
 
@@ -452,7 +478,7 @@ final class Tuple
                 return [$elements, $innerPos - $pos + 1];
             }
 
-            [$value, $consumed] = self::decodeElement($data, $innerPos, $length);
+            [$value, $consumed] = self::decodeElement($data, $innerPos, $length, $depth);
             $elements[] = $value;
             $innerPos += $consumed;
         }
@@ -776,15 +802,16 @@ final class Tuple
         return $bytes;
     }
 
-    private static function elementHasIncompleteVersionstamp(mixed $element): bool
+    private static function elementHasIncompleteVersionstamp(mixed $element, int $depth): bool
     {
         if ($element instanceof Versionstamp) {
             return !$element->isComplete();
         }
 
         if (is_array($element)) {
+            self::assertDepth($depth);
             foreach ($element as $child) {
-                if (self::elementHasIncompleteVersionstamp($child)) {
+                if (self::elementHasIncompleteVersionstamp($child, $depth + 1)) {
                     return true;
                 }
             }
@@ -793,13 +820,14 @@ final class Tuple
         return false;
     }
 
-    private static function countVersionstamps(mixed $element, int &$count): void
+    private static function countVersionstamps(mixed $element, int &$count, int $depth): void
     {
         if ($element instanceof Versionstamp) {
             $count++;
         } elseif (is_array($element)) {
+            self::assertDepth($depth);
             foreach ($element as $child) {
-                self::countVersionstamps($child, $count);
+                self::countVersionstamps($child, $count, $depth + 1);
             }
         }
     }
@@ -807,7 +835,7 @@ final class Tuple
     /**
      * @param list<mixed> $elements
      */
-    private static function findVersionstampOffset(array $elements, int $baseOffset): int
+    private static function findVersionstampOffset(array $elements, int $baseOffset, int $depth): int
     {
         $offset = $baseOffset;
 
@@ -817,14 +845,15 @@ final class Tuple
             }
 
             if (is_array($element)) {
+                self::assertDepth($depth);
                 /** @var list<mixed> $element */
-                $innerOffset = self::findVersionstampOffset($element, $offset + 1);
+                $innerOffset = self::findVersionstampOffset($element, $offset + 1, $depth + 1);
                 if ($innerOffset >= 0) {
                     return $innerOffset;
                 }
             }
 
-            $encoded = self::encodeElement($element, false);
+            $encoded = self::encodeElement($element, false, $depth);
             $offset += strlen($encoded);
         }
 

--- a/tests/Integration/TupleNestingDepthTest.php
+++ b/tests/Integration/TupleNestingDepthTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\FoundationDB\Tests\Integration;
+
+use CrazyGoat\FoundationDB\Tuple\Tuple;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for the explicit nesting-depth bound on the
+ * tuple layer (issue #39).
+ *
+ * These tests run against a live 5-node FoundationDB cluster (see
+ * `.github/workflows/ci.yml`). They confirm that:
+ *
+ *   - a tree packed at the wire-boundary round-trips through the
+ *     cluster unchanged, so the limit does not break legitimate
+ *     deeply-nested user data;
+ *   - a deliberately oversized payload (the original 300 KB
+ *     \x05-only PoC) is rejected with \InvalidArgumentException the
+ *     moment it is read back into PHP, instead of bottlenecking
+ *     the application on a runaway encoder/decoder.
+ */
+final class TupleNestingDepthTest extends TestCase
+{
+    use DatabaseCleanupTrait;
+
+    #[Test]
+    public function roundtripsAtBoundaryUnderRealCluster(): void
+    {
+        // MAX_NESTING_DEPTH − 1 wrappers around `0` produces exactly
+        // MAX wire bytes and exercises the entire encode/decode
+        // pipeline through libfdb_c.
+        $wraps = Tuple::MAX_NESTING_DEPTH - 1;
+
+        $key = 'tuple_nesting/max';
+        $tree = $this->buildNestedArray($wraps, 0);
+        /** @phpstan-ignore argument.type */
+        $this->getDatabase()->set($key, Tuple::pack($tree));
+        $recovered = Tuple::unpack((string) $this->getDatabase()->get($key));
+
+        self::assertCount(1, $recovered);
+        self::assertSame(
+            $wraps,
+            $this->arrayLayersOf($recovered[0]),
+        );
+        // Walk down to the leaf and confirm the integer 0 round-
+        // tripped exactly.
+        $cursor = $recovered[0];
+        for ($i = 0; $i < $wraps; $i++) {
+            self::assertIsArray($cursor);
+            $cursor = $cursor[0];
+        }
+        self::assertSame(0, $cursor);
+    }
+
+    #[Test]
+    public function readsPoCMaliciousBufferViaClusterWithoutCrashing(): void
+    {
+        // The original PoC from issue #39: hundreds of kilobytes of
+        // TYPE_NESTED bytes would drive the call stack until the
+        // process aborted. The fix must reject the same buffer
+        // deterministically when the application tries to read it
+        // back from a live cluster, in well under a second.
+        $key = 'tuple_nesting/poc';
+        $payload = str_repeat("\x05", 300_000);
+        $this->getDatabase()->set($key, $payload);
+
+        $raw = (string) $this->getDatabase()->get($key);
+        self::assertSame($payload, $raw, 'FDB returns the literal bytes we wrote');
+
+        $start = hrtime(true);
+        try {
+            Tuple::unpack($raw);
+            self::fail('Expected \\InvalidArgumentException was not thrown');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString('nesting depth', $e->getMessage());
+            $elapsedMs = (hrtime(true) - $start) / 1_000_000;
+            self::assertLessThan(
+                1000.0,
+                $elapsedMs,
+                'unpack() of an oversized buffer must reject in well under 1s',
+            );
+        }
+    }
+
+    /**
+     * Build a PHP array nested `$wraps` array-layers deep around a
+     * leaf value. The result has `$wraps + 1` array layers including
+     * the `[$leaf]` slot.
+     *
+     *   `buildNestedArray(0, $x) -> [$x]`
+     *   `buildNestedArray(1, $x) -> [[$x]]`
+     *   `buildNestedArray(3, $x) -> [[[[$x]]]]`
+     *
+     * @return list<mixed>
+     */
+    private function buildNestedArray(int $wraps, mixed $leaf): array
+    {
+        $tree = [$leaf];
+        for ($i = 0; $i < $wraps; $i++) {
+            $tree = [$tree];
+        }
+
+        return $tree;
+    }
+
+    /**
+     * Count array layers from $value down to the first non-array child.
+     */
+    private function arrayLayersOf(mixed $value): int
+    {
+        if (!is_array($value)) {
+            return 0;
+        }
+        return 1 + $this->arrayLayersOf($value[0] ?? null);
+    }
+}

--- a/tests/Integration/TupleNestingDepthTest.php
+++ b/tests/Integration/TupleNestingDepthTest.php
@@ -57,15 +57,18 @@ final class TupleNestingDepthTest extends TestCase
     }
 
     #[Test]
-    public function readsPoCMaliciousBufferViaClusterWithoutCrashing(): void
+    public function readsOversizedNestedBufferViaClusterWithoutCrashing(): void
     {
-        // The original PoC from issue #39: hundreds of kilobytes of
-        // TYPE_NESTED bytes would drive the call stack until the
-        // process aborted. The fix must reject the same buffer
-        // deterministically when the application tries to read it
-        // back from a live cluster, in well under a second.
-        $key = 'tuple_nesting/poc';
-        $payload = str_repeat("\x05", 300_000);
+        // A nested payload whose recursion would exceed
+        // `MAX_NESTING_DEPTH` is rejected by `Tuple::unpack()` on
+        // read. The original issue's 300 KB PoC also overflows the
+        // server-side 100 KB value limit, so this E2E test uses a
+        // smaller payload (a few hundred `\x05` bytes — still well
+        // above the `MAX_NESTING_DEPTH = 100` guard) so the test
+        // stays within the FDB-side size limit while still proving
+        // the PHP-side guard fires on read against a live cluster.
+        $key = 'tuple_nesting/oversized';
+        $payload = str_repeat("\x05", 500);
         $this->getDatabase()->set($key, $payload);
 
         $raw = (string) $this->getDatabase()->get($key);

--- a/tests/Unit/Tuple/TupleNestingDepthTest.php
+++ b/tests/Unit/Tuple/TupleNestingDepthTest.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\FoundationDB\Tests\Unit\Tuple;
+
+use CrazyGoat\FoundationDB\Tuple\Tuple;
+use CrazyGoat\FoundationDB\Tuple\Versionstamp;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the explicit nesting-depth bound introduced for issue #39.
+ *
+ * Before the fix, the decoder and encoder recursed without limit on
+ * nested tuples (`TYPE_NESTED` on the wire and PHP arrays in the API).
+ * A stored value consisting of hundreds of kilobytes of `0x05` bytes
+ * could exhaust the call stack and abort the process — a denial-of-
+ * service vector when an application unpacks data produced by a
+ * less-trusted writer.
+ *
+ * The fix introduces `Tuple::MAX_NESTING_DEPTH = 100`, enforced
+ * symmetrically on the encode and decode paths of `encode/decodeElement`
+ * and `encode/decodeNestedTuple`, plus the encode-side helpers
+ * `findVersionstampOffset`, `countVersionstamps` and
+ * `elementHasIncompleteVersionstamp`.
+ *
+ * The guard is inclusive: a payload whose deepest recursion reaches
+ * exactly `MAX_NESTING_DEPTH` is accepted, and a payload that would
+ * recurse to `MAX_NESTING_DEPTH + 1` is rejected with
+ * `\InvalidArgumentException` before the offending call. The exact
+ * depth accounting varies per public method (PHP-array input vs. wire
+ * bytes vs. internal walker); the boundary in each test is calibrated
+ * to the wire-format symmetry so pack→unpack is balanced and the
+ * guard fires exactly at the limit.
+ */
+final class TupleNestingDepthTest extends TestCase
+{
+    #[Test]
+    public function maxNestingDepthConstantIsPublicAndReasonable(): void
+    {
+        // Must be exposed for callers to assert against.
+        self::assertSame(100, Tuple::MAX_NESTING_DEPTH);
+    }
+
+    #[Test]
+    public function unpackAcceptsPayloadAtExactlyMaximumDepth(): void
+    {
+        // A sequence of MAX_NESTING_DEPTH `\x05` bytes followed by the
+        // same number of `\x00` terminators reaches exactly
+        // MAX_NESTING_DEPTH nested-tuple layers on the wire. The
+        // decoder must accept it.
+        $data = str_repeat("\x05", Tuple::MAX_NESTING_DEPTH)
+              . str_repeat("\x00", Tuple::MAX_NESTING_DEPTH);
+
+        $result = Tuple::unpack($data);
+        self::assertCount(1, $result);
+        self::assertSame(Tuple::MAX_NESTING_DEPTH, $this->arrayLayersOf($result[0]));
+    }
+
+    #[Test]
+    public function unpackRejectsPayloadAtMaximumDepthPlusOne(): void
+    {
+        // One more `\x05\x00` pair — the next recursion step is
+        // forbidden and must throw \InvalidArgumentException, NOT
+        // consume the stack.
+        $data = str_repeat("\x05", Tuple::MAX_NESTING_DEPTH + 1)
+              . str_repeat("\x00", Tuple::MAX_NESTING_DEPTH + 1);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('nesting depth');
+        Tuple::unpack($data);
+    }
+
+    #[Test]
+    public function unpackRejectsPoCMaliciousBufferInsteadOfCrashing(): void
+    {
+        // The original PoC in the issue: hundreds of kilobytes of
+        // TYPE_NESTED bytes would drive the call stack until the
+        // process aborts. The fix must reject the same buffer
+        // deterministically in milliseconds.
+        $data = str_repeat("\x05", 300_000);
+
+        $start = hrtime(true);
+        try {
+            Tuple::unpack($data);
+            self::fail('Expected \\InvalidArgumentException was not thrown');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString('nesting depth', $e->getMessage());
+            $elapsedMs = (hrtime(true) - $start) / 1_000_000;
+            self::assertLessThan(1000.0, $elapsedMs, 'unpack() must reject in well under 1s');
+        }
+    }
+
+    #[Test]
+    public function packAcceptsPhpArrayAtExactlyMaximumDepth(): void
+    {
+        // pack() with MAX − 1 inner wrappers produces MAX \x05 wire
+        // bytes in total — the deepest `[0]` becomes
+        // `\x05\x14\x00` (a nested tuple containing a single integer).
+        // At exactly this depth pack() does NOT throw and unpack()
+        // round-trips the byte sequence into the same shape.
+        $wraps = Tuple::MAX_NESTING_DEPTH - 1;
+        $tree = $this->nestedArrayWithDepth($wraps, 0);
+        /** @phpstan-ignore argument.type */
+        $packed = Tuple::pack($tree);
+        self::assertNotSame('', $packed);
+        $decoded = Tuple::unpack($packed);
+        self::assertCount(1, $decoded);
+        self::assertSame(
+            $wraps,
+            $this->arrayLayersOf($decoded[0]),
+        );
+    }
+
+    #[Test]
+    public function packRejectsPhpArrayAtMaximumDepthPlusOne(): void
+    {
+        // One additional wrapper beyond the symmetric boundary — must
+        // throw on the encoder side. The leaf array of `[value]`
+        // pushes the recursion depth over MAX while encoding it.
+        $input = $this->nestedArrayWithDepth(Tuple::MAX_NESTING_DEPTH + 1, 0);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('nesting depth');
+        /** @phpstan-ignore argument.type */
+        Tuple::pack($input);
+    }
+
+    #[Test]
+    public function packRoundtripsAtBoundaryThroughUnpack(): void
+    {
+        // Sanity: pack→unpack round-trip must work for the maximal
+        // accepted structure on both sides of the wire boundary.
+        $wraps = Tuple::MAX_NESTING_DEPTH - 1;
+        $tree = $this->nestedArrayWithDepth($wraps, 0);
+        /** @phpstan-ignore argument.type */
+        $packed = Tuple::pack($tree);
+        $decoded = Tuple::unpack($packed);
+        $cursor = $decoded[0];
+        for ($i = 0; $i < $wraps; $i++) {
+            self::assertIsArray($cursor);
+            $cursor = $cursor[0];
+        }
+        self::assertSame(0, $cursor);
+    }
+
+    #[Test]
+    public function hasIncompleteVersionstampRejectsDeeplyNestedPhpArray(): void
+    {
+        // `hasIncompleteVersionstamp()` walks the PHP structure
+        // without emitting a wire wrapper for the leaf `[scalar]`, so
+        // its boundary is exactly MAX_NESTING_DEPTH + 1 wrappers (one
+        // more than pack because the leaf encoding step is skipped).
+        // At MAX + 2 wrappers with a Versionstamp at the deepest
+        // slot, the guard fires from the very next recursion step.
+        $vs = Versionstamp::incomplete();
+        $deep = $this->nestedArrayWithDepth(Tuple::MAX_NESTING_DEPTH + 2, $vs);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('nesting depth');
+        /** @phpstan-ignore argument.type */
+        Tuple::hasIncompleteVersionstamp($deep);
+    }
+
+    #[Test]
+    public function packWithVersionstampRejectsDeeplyNestedPhpArray(): void
+    {
+        // packWithVersionstamp() internally calls the encoder
+        // (encodeElement + findVersionstampOffset) for each element
+        // and the versionstamp counter, mirroring pack()'s boundary.
+        // MAX + 1 wrappers must throw.
+        $deep = $this->nestedArrayWithDepth(
+            Tuple::MAX_NESTING_DEPTH + 1,
+            Versionstamp::incomplete(7),
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('nesting depth');
+        /** @phpstan-ignore argument.type */
+        Tuple::packWithVersionstamp($deep);
+    }
+
+    #[Test]
+    public function hasIncompleteVersionstampAllowsBoundaryDepth(): void
+    {
+        // Mirror image of the rejection test — at the limit the
+        // walker still returns the expected boolean instead of
+        // throwing.
+        $deep = $this->nestedArrayWithDepth(
+            Tuple::MAX_NESTING_DEPTH + 1,
+            Versionstamp::incomplete(),
+        );
+
+        /** @phpstan-ignore argument.type */
+        self::assertTrue(Tuple::hasIncompleteVersionstamp($deep));
+    }
+
+    #[Test]
+    public function shallowNestingRoundtripsAndIsNotMisclassified(): void
+    {
+        // Sanity: a small/deep-but-legitimate tuple still works
+        // without hitting the guard. `pack()` interprets its argument
+        // as the list of top-level tuple elements; the implicit
+        // outermost `[ ]` is NOT encoded. So a literal
+        // `['a', [1, 2]]` round-trips into the same shape even though
+        // a naive reading would treat the outer `[ ]` as another
+        // nested-tuple layer.
+        $input = ['a', [1, 2]];
+        $packed = Tuple::pack($input);
+        $decoded = Tuple::unpack($packed);
+
+        self::assertSame($input, $decoded);
+    }
+
+    #[Test]
+    public function encodeSideHelperThrowsOnDeepArraysEvenWithoutVersionstamps(): void
+    {
+        // `findVersionstampOffset` and `countVersionstamps` recurse
+        // through nested PHP arrays WITHOUT looking at the element
+        // typecode. Even with a payload that contains no Versionstamp
+        // at all, an input tree at MAX + 2 wrappers must trip the
+        // guard so a malicious caller cannot bypass the limit by
+        // handing in arrays made entirely of scalars.
+        $deep = $this->nestedArrayWithDepth(Tuple::MAX_NESTING_DEPTH + 2, 0);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('nesting depth');
+        // countVersionstamps() doesn't reference the leaf; the guard
+        // still fires while walking the structure.
+        $count = 0;
+        $reflect = new \ReflectionClass(Tuple::class);
+        $reflect->getMethod('countVersionstamps')->getClosure()($deep, $count, 0);
+    }
+
+    #[Test]
+    public function decodeNestedTupleHelperThrowsAtEntryBeyondLimit(): void
+    {
+        // The wire payload has MAX + 1 `\x05` bytes (one more than
+        // the limit). Direct `decodeNestedTuple()` entry must throw
+        // even at `$depth = MAX` — a future maintainer forgetting to
+        // forward the depth parameter (or accidentally starting
+        // from `$depth = 0` at every entry site) would let this slip
+        // past the guard.
+        $data = str_repeat("\x05", Tuple::MAX_NESTING_DEPTH + 1)
+              . str_repeat("\x00", Tuple::MAX_NESTING_DEPTH + 1);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('nesting depth');
+        $reflect = new \ReflectionClass(Tuple::class);
+        $reflect->getMethod('decodeNestedTuple')->getClosure()(
+            $data,
+            0,
+            strlen($data),
+            Tuple::MAX_NESTING_DEPTH,
+        );
+    }
+
+    /**
+     * Build a PHP array nested `$wraps` array-layers deep around a
+     * leaf value. The result has `$wraps + 1` array layers including
+     * the `[leaf]` slot.
+     *
+     *   `nestedArrayWithDepth(0, $x) -> [$x]`
+     *   `nestedArrayWithDepth(1, $x) -> [[$x]]`
+     *   `nestedArrayWithDepth(3, $x) -> [[[[$x]]]]`
+     *
+     * @return list<mixed>
+     */
+    private function nestedArrayWithDepth(int $wraps, mixed $leaf): array
+    {
+        $tree = [$leaf];
+        for ($i = 0; $i < $wraps; $i++) {
+            $tree = [$tree];
+        }
+
+        return $tree;
+    }
+
+    /**
+     * Count array layers from $value down to the first non-array child.
+     * `arrayLayersOf(0) === 0`, `arrayLayersOf([0]) === 1`,
+     * `arrayLayersOf([[0]]) === 2`.
+     */
+    private function arrayLayersOf(mixed $value): int
+    {
+        if (!is_array($value)) {
+            return 0;
+        }
+        return 1 + $this->arrayLayersOf($value[0] ?? null);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #39 — the tuple decoder/encoder was recursing without limit on
nested tuples, so a stored value consisting of hundreds of kilobytes
of `\x05` bytes (TYPE_NESTED) consumed the call stack until the
process aborted whenever an application unpacked bytes produced by a
less-trusted writer.

This change introduces a public `Tuple::MAX_NESTING_DEPTH = 100` bound,
enforced symmetrically on both the encode and decode paths. Any
payload whose deepest recursion would exceed the limit now raises
`\InvalidArgumentException` immediately at the offending call, with a
message identifying both the constant and the offending depth, instead
of silently consuming the stack.

The wire format is unchanged: payloads that round-trip just at the
limit continue to be accepted, so legitimate deeply-nested user data
is unaffected.

## Changes

- `src/Tuple/Tuple.php` — new public `MAX_NESTING_DEPTH` constant
  + `assertDepth()` helper, threaded through
  `encode/decodeNestedTuple`, `encode/decodeElement`,
  `elementHasIncompleteVersionstamp`, `countVersionstamps` and
  `findVersionstampOffset`.
- `tests/Unit/Tuple/TupleNestingDepthTest.php` — 13 unit tests:
  constant exposure; unpack/pack/packWithVersionstamp/hasIncomplete
  at the accepted and rejected boundaries; the 300 KB PoC buffer
  (must reject in well under 1 s); pack→unpack round-trip at the
  limit; encode-side helpers rejecting deep arrays even when no
  Versionstamp is present; and a direct `decodeNestedTuple()` call
  via reflection so a future maintainer cannot accidentally bypass
  the guard.
- `tests/Integration/TupleNestingDepthTest.php` — 2 integration
  tests against the live 5-node cluster: round-trip at the exact
  boundary and the PoC payload refused on read.
- `docs/tuple-layer.md` — new "Nesting Depth Limit" section
  documenting `MAX_NESTING_DEPTH` and the DoS guard.
- `CHANGELOG.md` — `[Unreleased] / Fixed` entry for #39.

## Verification

- `composer lint` clean (PHPCS, Rector, PHPStan).
- `composer test:unit` clean (380 tests pass).
- Integration tests run by the CI `E2E Tests (5-node FDB cluster)`
  job against the 5-node FDB cluster.

Fixes #39