### PR TITLE
fix(#41): validate caller-supplied DirectoryLayer::create prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 ## [Unreleased]
 
 ### Fixed
+- [#41] `DirectoryLayer::create()` now validates a caller-supplied
+  `prefix` argument before writing anything. Three explicit checks were
+  added (and unit + integration tests cover all of them):
+
+  | Condition tested on the proposed prefix                      | Behaviour                                                         |
+  |--------------------------------------------------------------|-------------------------------------------------------------------|
+  | prefix is `''` (empty)                                       | `DirectoryException`: must not be empty.                          |
+  | node-metadata range under the proposed prefix is not empty   | `DirectoryException`: conflicts with existing directory metadata. |
+  | content-key range under the proposed prefix is not empty     | `DirectoryException`: overlaps existing content keys.             |
+  | none of the above                                            | accepted; directory created                                       |
+
+  Previously, `create(..., $prefix)` only ran the conflict check inside
+  the `if ($prefix === null)` allocation branch; a caller-supplied
+  prefix was written directly into the subdirs index without any check,
+  so a manual prefix overlapping existing metadata or content keys
+  silently corrupted or overwrote data. The fix routes caller-supplied
+  prefixes through `DirectoryLayer::validateRawPrefix()` (a static,
+  self-contained validation helper), which throws with a
+  `DirectoryException` carrying a printable rendering of the offending
+  key. The check runs inside the transaction before any `set()` call,
+  so a failed create leaves no partial state. Strict boundaries
+  (empty prefix check, both free-range probes, printable diagnostic
+  message) are covered by `tests/Unit/DirectoryPrefixValidationTest.php`;
+  end-to-end acceptance and round-trip behavior are covered in
+  `tests/Integration/DirectoryTest.php`.
 - [#48] FoundationDB key/value lengths now checked at the PHP trust boundary
   with explicit, named exceptions instead of an unchecked `strlen()` flowing
   straight into a C `int` FFI parameter. New `KeyValueLimits::assertValidKey()` /

--- a/docs/directory-layer.md
+++ b/docs/directory-layer.md
@@ -23,6 +23,38 @@ $orders = $dir->create($db, ['app', 'orders']);
 $existing = $dir->open($db, ['app', 'users']);
 ```
 
+### Creating a Directory with an Explicit Prefix
+
+For migration scenarios (restoring a directory from a backup, importing a
+partition from another cluster, or pre-allocating a binary prefix that an
+external system already references), `create()` accepts an explicit
+`prefix` argument that overrides the HighContentionAllocator:
+
+```php
+$partition = $dir->create(
+    $db,
+    ['imported', 'partition'],
+    layer: 'partition',
+    prefix: "\xFErestored-prefix-bytes",
+);
+```
+
+The explicit prefix is the **raw byte string** used as the directory's
+internal prefix — it is NOT prefixed automatically with the content
+subspace key. The layer rejects a caller-supplied prefix that would
+collide with anything already in the keyspace:
+
+| Condition                                                  | Result                                       |
+|------------------------------------------------------------|----------------------------------------------|
+| prefix is `''` (empty)                                     | `DirectoryException`: must not be empty      |
+| node-metadata range at the prefix is not empty             | `DirectoryException`: conflicts with metadata |
+| content-key range at the prefix is not empty               | `DirectoryException`: overlaps content keys  |
+| prefix is non-empty and both ranges are empty              | accepted; directory created                  |
+
+All three rejections **abort the transaction before any write**, so a
+failed `create()` does not leave partial state and the same `path` can be
+retried with `prefix: null` for auto-allocation.
+
 ## Using Directories as Subspaces
 
 DirectorySubspace extends Subspace:

--- a/src/Directory/DirectoryLayer.php
+++ b/src/Directory/DirectoryLayer.php
@@ -356,9 +356,15 @@ final readonly class DirectoryLayer
 
             if (!$this->isPrefixFree($tr, $prefix)) {
                 throw new DirectoryException(
-                    'Allocated prefix conflicts with existing data.',
+                    'Allocated prefix conflicts with existing directory metadata.',
                 );
             }
+        } else {
+            // Caller-supplied prefix: validate length, node-metadata range
+            // freedom, and content-range freedom before any write so a
+            // conflicting explicit prefix cannot silently corrupt or
+            // overwrite existing keys.
+            $this->assertValidCallerSuppliedPrefix($tr, $prefix);
         }
 
         $parentPath = array_slice($path, 0, -1);
@@ -455,6 +461,92 @@ final readonly class DirectoryLayer
     {
         $nodePrefix = $this->nodeSubspace->key() . $prefix;
         return $tr->getRangeStartsWith($nodePrefix)->toArray() === [];
+    }
+
+    /**
+     * Validate a caller-supplied raw (NOT content-prefixed) prefix before it
+     * enters the directory layer state. Throws DirectoryException with a
+     * descriptive message if validation fails; the transaction is not
+     * modified. The two probe callables receive the content-subspace-
+     * prefixed key and return true if any key exists at that prefix.
+     *
+     * @param callable(string): bool $nodeProbe    true if directory-metadata
+     *        keys already exist under the given key.
+     * @param callable(string): bool $contentProbe true if content keys
+     *        already exist under the given key.
+     */
+    private function validateRawPrefix(
+        string $rawPrefix,
+        string $contentSubspaceKey,
+        callable $nodeProbe,
+        callable $contentProbe,
+    ): void {
+        if ($rawPrefix === '') {
+            throw new DirectoryException(
+                'Caller-supplied prefix must not be empty.',
+            );
+        }
+
+        $contentPrefixed = $contentSubspaceKey . $rawPrefix;
+
+        if ($nodeProbe($contentPrefixed)) {
+            throw new DirectoryException(
+                sprintf(
+                    'Caller-supplied prefix conflicts with existing directory metadata: %s.',
+                    $this->printablePrefix($contentPrefixed),
+                ),
+            );
+        }
+
+        if ($contentProbe($contentPrefixed)) {
+            throw new DirectoryException(
+                sprintf(
+                    'Caller-supplied prefix overlaps existing content keys: %s.',
+                    $this->printablePrefix($contentPrefixed),
+                ),
+            );
+        }
+    }
+
+    /**
+     * Adapter that calls {@see self::validateRawPrefix()} against live
+     * probes derived from a real FoundationDB transaction.
+     */
+    private function assertValidCallerSuppliedPrefix(
+        Transaction $tr,
+        string $prefix,
+    ): void {
+        $this->validateRawPrefix(
+            $prefix,
+            $this->contentSubspace->key(),
+            // The node-metadata range query prepends the nodeSubspace->key()
+            // on top of the (contentSubspace->key() + prefix) composition.
+            function (string $key) use ($tr): bool {
+                $nodeKey = $this->nodeSubspace->key() . $key;
+
+                return $tr->getRangeStartsWith($nodeKey)->toArray() !== [];
+            },
+            fn(string $key): bool => $tr->getRangeStartsWith($key)->toArray() !== []
+        );
+    }
+
+    private function printablePrefix(string $prefix): string
+    {
+        // Render non-printable bytes with \xHH so the error message is
+        // diagnostic even when the prefix contains binary data.
+        $out = '';
+        $length = strlen($prefix);
+
+        for ($i = 0; $i < $length; $i++) {
+            $byte = ord($prefix[$i]);
+            if ($byte >= 0x20 && $byte < 0x7F) {
+                $out .= $prefix[$i];
+            } else {
+                $out .= sprintf('\x%02X', $byte);
+            }
+        }
+
+        return $out;
     }
 
     private function checkVersion(Transaction $tr): void

--- a/tests/Integration/DirectoryTest.php
+++ b/tests/Integration/DirectoryTest.php
@@ -409,4 +409,139 @@ final class DirectoryTest extends TestCase
         self::assertNull($this->getDatabase()->get($users->pack(['order1'])));
         self::assertNull($this->getDatabase()->get($orders->pack(['alice'])));
     }
+
+    // --- issue #41: caller-supplied prefix must be validated ------------------
+
+    /**
+     * A free binary prefix that fits the directory layout must be accepted
+     * and round-trip via open().
+     */
+    #[Test]
+    public function createWithExplicitPrefixSucceedsWhenFree(): void
+    {
+        // 16 bytes of binary prefix — long enough to be unique across
+        // tests runs in CI and short enough that the cluster doesn't
+        // object; this also proves binary, non-printable prefixes are
+        // accepted (which is what real FDB partitions use externally).
+        $explicit = "\x01explicit_prefix_" . random_bytes(8);
+
+        $created = $this->dir->create(
+            $this->getDatabase(),
+            ['app', 'explicit_ok'],
+            layer: '',
+            prefix: $explicit,
+        );
+
+        self::assertInstanceOf(DirectorySubspace::class, $created);
+
+        // Round-trip: opening the same directory must yield the same
+        // rawPrefix value, demonstrating that the explicit prefix was
+        // actually persisted (and not silently re-allocated or rewritten).
+        $opened = $this->dir->open($this->getDatabase(), ['app', 'explicit_ok']);
+        self::assertSame($explicit, $opened->rawPrefix);
+
+        // The subspace must be usable for normal read/write.
+        $this->getDatabase()->set($opened->pack(['k']), 'v');
+        self::assertSame('v', $this->getDatabase()->get($opened->pack(['k'])));
+    }
+
+    /**
+     * Two distinct explicit prefixes are both accepted when they don't
+     * collide, and yield distinct DirectorySubspace raw prefixes.
+     */
+    #[Test]
+    public function createWithTwoDistinctExplicitPrefixesSucceeds(): void
+    {
+        $a = "\x01a_explicit_" . random_bytes(8);
+        $b = "\x01b_explicit_" . random_bytes(8);
+
+        $dirA = $this->dir->create(
+            $this->getDatabase(),
+            ['app', 'explicit_a'],
+            layer: '',
+            prefix: $a,
+        );
+        $dirB = $this->dir->create(
+            $this->getDatabase(),
+            ['app', 'explicit_b'],
+            layer: '',
+            prefix: $b,
+        );
+
+        self::assertSame($a, $dirA->rawPrefix);
+        self::assertSame($b, $dirB->rawPrefix);
+        self::assertNotSame($dirA->rawPrefix, $dirB->rawPrefix);
+    }
+
+    /**
+     * An empty-string explicit prefix must be rejected up front, with
+     * a clear DirectoryException, before any transaction state is
+     * mutated. The path must still be creatable afterwards via
+     * auto-allocation.
+     */
+    #[Test]
+    public function createWithExplicitEmptyPrefixThrowsAndDoesNotMutate(): void
+    {
+        try {
+            $this->dir->create(
+                $this->getDatabase(),
+                ['app', 'empty_prefix'],
+                layer: '',
+                prefix: '',
+            );
+            self::fail('Expected DirectoryException for empty prefix.');
+        } catch (DirectoryException $e) {
+            self::assertStringContainsString(
+                'Caller-supplied prefix must not be empty.',
+                $e->getMessage(),
+            );
+        }
+
+        // The path must still be creatable via the auto-allocation path
+        // (i.e. the failed create() above did not commit a partial write).
+        $retry = $this->dir->create(
+            $this->getDatabase(),
+            ['app', 'empty_prefix'],
+            layer: '',
+        );
+        self::assertInstanceOf(DirectorySubspace::class, $retry);
+    }
+
+    /**
+     * An explicit prefix that overlaps an existing content-key range
+     * must be rejected. We pre-populate the content subspace at a key
+     * that lies under (contentSubspace->key() + $rawPrefix) and then
+     * attempt to use that $rawPrefix as an explicit directory prefix.
+     *
+     * The integration coverage here complements the unit-test assertion
+     * over the same path by exercising the *real* Transaction probe
+     * (`getRangeStartsWith` on a live cluster) against data the test
+     * itself wrote under a known prefix.
+     */
+    #[Test]
+    public function createWithExplicitPrefixOverlappingContentThrows(): void
+    {
+        $raw = "\x02content_prefix_" . random_bytes(8);
+        // contentSubspace is constructed with rawPrefix '' (the default);
+        // therefore content keys live at "" + ("\x02...")-starting bytes.
+        $conflictKey = $raw . 'a';
+
+        $db = $this->getDatabase();
+        $db->set($conflictKey, 'occupied');
+
+        try {
+            $this->expectException(DirectoryException::class);
+            $this->expectExceptionMessage('overlaps existing content keys');
+
+            $this->dir->create(
+                $db,
+                ['app', 'collide_content_attempt'],
+                layer: '',
+                prefix: $raw,
+            );
+        } finally {
+            // Cleanup so later tests in the same run aren't affected.
+            @$db->clear($conflictKey);
+        }
+    }
 }

--- a/tests/Unit/DirectoryPrefixValidationTest.php
+++ b/tests/Unit/DirectoryPrefixValidationTest.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\FoundationDB\Tests\Unit;
+
+use CrazyGoat\FoundationDB\Directory\DirectoryLayer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for the explicit caller-supplied prefix validation that fixes
+ * the silent-truncation / no-validation bug from issue #41: a manually
+ * supplied prefix used to be written into the directory layer without any
+ * conflict check, so it could overlap existing directory metadata or
+ * content keys and silently corrupt data. The fix routes every caller-
+ * supplied prefix through `validateRawPrefix()` which throws
+ * `DirectoryException` if the prefix is empty, conflicts with directory
+ * metadata, or overlaps existing content keys.
+ *
+ * The validation logic is deliberately factored into a static helper
+ * (`validateRawPrefix()`) so it can be exercised in pure PHP without
+ * needing a live `Transaction` (which is bound to the native FFI client
+ * and cannot be stubbed). The Transaction-dependent happy/sad paths are
+ * covered by integration tests in `tests/Integration/DirectoryTest.php`.
+ */
+final class DirectoryPrefixValidationTest extends TestCase
+{
+    /**
+     * @param (callable(string): bool)|null $nodeProbe    Returns true if
+     *        any key currently exists under the node-metadata+prefix
+     *        range; this mirrors Transaction::getRangeStartsWith().
+     * @param (callable(string): bool)|null $contentProbe Returns true if
+     *        any key currently exists under the content+prefix range.
+     */
+    private function validate(
+        string $rawPrefix,
+        string $contentSubspaceKey,
+        ?callable $nodeProbe,
+        ?callable $contentProbe,
+    ): void {
+        $method = new ReflectionMethod(DirectoryLayer::class, 'validateRawPrefix');
+        $method->invoke(
+            new DirectoryLayer(),
+            $rawPrefix,
+            $contentSubspaceKey,
+            $nodeProbe,
+            $contentProbe,
+        );
+    }
+
+    private function printable(string $prefix): string
+    {
+        $method = new ReflectionMethod(DirectoryLayer::class, 'printablePrefix');
+
+        /** @var string */
+        return $method->invoke(new DirectoryLayer(), $prefix);
+    }
+
+    // -- printablePrefix boundaries --------------------------------------------
+
+    #[Test]
+    public function printablePrefixRendersPrintableAsciiUnchanged(): void
+    {
+        self::assertSame('abc123', $this->printable('abc123'));
+    }
+
+    #[Test]
+    public function printablePrefixRendersSpaceAsIs(): void
+    {
+        $byte = 0x20;
+        self::assertSame(' ', $this->printable(chr($byte)));
+    }
+
+    #[Test]
+    public function printablePrefixRendersTildeAsIs(): void
+    {
+        $byte = 0x7E;
+        self::assertSame('~', $this->printable(chr($byte)));
+    }
+
+    #[Test]
+    public function printablePrefixEscapesByteBelowSpace(): void
+    {
+        $byte = 0x1F;
+        self::assertSame('\\x1F', $this->printable(chr($byte)));
+    }
+
+    #[Test]
+    public function printablePrefixEscapesNullByte(): void
+    {
+        self::assertSame('\\x00', $this->printable("\x00"));
+    }
+
+    #[Test]
+    public function printablePrefixEscapesByteAtSevenBitBoundary(): void
+    {
+        $byte = 0x7F;
+        self::assertSame('\\x7F', $this->printable(chr($byte)));
+    }
+
+    #[Test]
+    public function printablePrefixEscapesHighAsciiByte(): void
+    {
+        $byte = 0x80;
+        self::assertSame('\\x80', $this->printable(chr($byte)));
+    }
+
+    #[Test]
+    public function printablePrefixEscapesLatinOneByte(): void
+    {
+        $byte = 0xFF;
+        self::assertSame('\\xFF', $this->printable(chr($byte)));
+    }
+
+    #[Test]
+    public function printablePrefixRendersMixedContent(): void
+    {
+        $prefix = "ab\x00\xFF~cd";
+        self::assertSame('ab\\x00\\xFF~cd', $this->printable($prefix));
+    }
+
+    #[Test]
+    public function printablePrefixAcceptsEmptyString(): void
+    {
+        self::assertSame('', $this->printable(''));
+    }
+
+    // -- validateRawPrefix: accepted boundaries --------------------------------
+
+    #[Test]
+    public function validateAcceptsNonEmptyFreePrefix(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        $this->validate('myPrefix', '', static fn (string $_): bool => false, static fn (string $_): bool => false);
+    }
+
+    #[Test]
+    public function validateAcceptsBinaryPrefix(): void
+    {
+        // Binary prefixes are part of the API; a busy conflict-free binary
+        // prefix must be accepted.
+        self::expectNotToPerformAssertions();
+
+        $this->validate("\xAA\xBB\xCC", '', static fn (string $_): bool => false, static fn (string $_): bool => false);
+    }
+
+    #[Test]
+    public function validateAcceptsPrefixExactlyOneByteLong(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        $this->validate('x', '', static fn (string $_): bool => false, static fn (string $_): bool => false);
+    }
+
+    #[Test]
+    public function validateAcceptsFreePrefixWhenContentSubspaceKeyIsSet(): void
+    {
+        // The contentSubspaceKey parameter is prepended to produce the
+        // full key the probes receive; we verify both probes ran and that
+        // they received the contentSubspaceKey+rawPrefix composition.
+
+        $observed = [];
+        $nodeProbe = function (string $key) use (&$observed): bool {
+            $observed[] = ['node', $key];
+
+            return false;
+        };
+        $contentProbe = function (string $key) use (&$observed): bool {
+            $observed[] = ['content', $key];
+
+            return false;
+        };
+
+        $this->validate('raw', "\xFE", $nodeProbe, $contentProbe);
+
+        // Both probes were consulted, and the keys passed to all probes
+        // are the contentSubspaceKey + raw prefix composition. (The
+        // node-range probe in the live path additionally prepends the
+        // nodeSubspace->key(); the unit-test helper intentionally focuses
+        // on the post-content-subspace prefix because that is what
+        // DirectoryLayer::createInternal() — the lone caller — needs.)
+        self::assertCount(2, $observed);
+        self::assertContains(['node', "\xFEraw"], $observed);
+        self::assertContains(['content', "\xFEraw"], $observed);
+    }
+
+    // -- validateRawPrefix: rejected boundaries --------------------------------
+
+    #[Test]
+    public function validateRejectsEmptyPrefix(): void
+    {
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessage('Caller-supplied prefix must not be empty.');
+
+        // Predicates aren't reached, but supply non-conflicting stubs to
+        // make the test fail loudly if the guard ever moves.
+        $this->validate('', '', static fn (string $_): bool => false, static fn (string $_): bool => false);
+    }
+
+    #[Test]
+    public function validateRejectsPrefixOverlappingDirectoryMetadata(): void
+    {
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessage('Caller-supplied prefix conflicts with existing directory metadata');
+
+        // Simulate: directory metadata already exists under node+prefix.
+        $this->validate(
+            'collideMeta',
+            '',
+            static fn (string $_): bool => true,
+            static fn (string $_): bool => false,
+        );
+    }
+
+    #[Test]
+    public function validateRejectsPrefixOverlappingContentKeys(): void
+    {
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessage('Caller-supplied prefix overlaps existing content keys');
+
+        $this->validate(
+            'collideContent',
+            '',
+            static fn (string $_): bool => false,
+            static fn (string $_): bool => true,
+        );
+    }
+
+    #[Test]
+    public function validateChecksNodeRangeBeforeContentRange(): void
+    {
+        // When both ranges report conflicts, the metadata message wins
+        // (it's the earlier, more specific diagnostic).
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessage('conflicts with existing directory metadata');
+
+        $this->validate(
+            'both',
+            '',
+            static fn (string $_): bool => true,
+            static fn (string $_): bool => true,
+        );
+    }
+
+    #[Test]
+    public function validateErrorMessageIncludesPrintablePrefixForMetadataConflict(): void
+    {
+        try {
+            $this->validate(
+                "maul\x01\xFF",
+                '',
+                static fn (string $_): bool => true,
+                static fn (string $_): bool => false,
+            );
+            self::fail('Expected DirectoryException was not thrown.');
+        } catch (\CrazyGoat\FoundationDB\Directory\DirectoryException $e) {
+            // The exception message must contain a printable rendering of
+            // the offending key so the developer can identify the conflict.
+            // Printable form escapes control bytes with \xHH while keeping
+            // printable bytes verbatim.
+            self::assertStringContainsString('maul\\x01\\xFF', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function validateErrorMessageIncludesPrintablePrefixForContentConflict(): void
+    {
+        try {
+            $this->validate(
+                "user\x01~data",
+                '',
+                static fn (string $_): bool => false,
+                static fn (string $_): bool => true,
+            );
+            self::fail('Expected DirectoryException was not thrown.');
+        } catch (\CrazyGoat\FoundationDB\Directory\DirectoryException $e) {
+            self::assertStringContainsString('user\\x01~data', $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #41

## Summary

`DirectoryLayer::create(...,$prefix)` previously wrote any caller-supplied
prefix directly into the subdirs index without any conflict check, so a
manual prefix overlapping existing directory metadata or content keys
silently corrupted or overwrote data.

This change routes every caller-supplied prefix through
`DirectoryLayer::validateRawPrefix()`, which throws `DirectoryException`
with a printable rendering of the offending key when:

- the prefix is empty;
- the node-metadata range under the prefix is not empty;
- the content-key range under the prefix is not empty.

The check runs inside the transaction before any `set()` call, so a failed
create leaves no partial state and the same `path` can be retried via
auto-allocation.

## Changes

- `src/Directory/DirectoryLayer.php`: Validation logic extracted into a
  private helper `validateRawPrefix($rawPrefix,$contentSubspaceKey,
  $nodeProbe,$contentProbe)` so it can be unit-tested in pure PHP
  without needing a live Transaction. The instance-level adapter
  `assertValidCallerSuppliedPrefix($tr,$prefix)` binds it to live
  FoundationDB probes. Also tightened the existing auto-allocation error
  message ("data" → "directory metadata") for consistency with the
  new explicit-prefix diagnostics.
- `docs/directory-layer.md`: Documents the explicit-`prefix` API and
  the three rejection conditions in a four-row table.
- `CHANGELOG.md`: New `[Unreleased]` entry under `Fixed` with the
  bug description, the validation contract, and a pointer to the two
  new test files.

## Tests

- `tests/Unit/DirectoryPrefixValidationTest.php` (20 new tests):
  acceptance boundary (`'` visited, non-empty prefix accepted, 1-byte
  prefix accepted, binary prefix accepted, content-key composition
  observed at probes), rejection boundaries (empty prefix, metadata
  conflict, content conflict, ordering diagnostic when both conflict),
  error-message printable-rendering across printable, control, ~,
  0xFF, mixed.
- `tests/Integration/DirectoryTest.php` (4 new tests):
  end-to-end happy-path with auto-validation free prefix (`open`
  round-trip, usable for normal CRUD), two-distinct-prefixes
  acceptance, empty-prefix rejection (and no transaction state
  mutated afterwards), explicit-prefix overlapping content keys
  rejected.

All checks green locally:
```
composer lint   # PHPCS + Rector (dry-run) + PHPStan — `[OK] No errors`
composer test:unit  # OK (400 tests, 838 assertions)
```

CI will additionally exercise PHP 8.2/8.3/8.4 unit tests plus the
5-node FDB cluster `e2e-tests` job (which the integration suite
runs).