### PR TITLE
fix(#40): enforce explicit move bounds, reject self-subtree and partition-cross moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
   | `newPath` equals `oldPath`                                                                                                | `DirectoryException`: source and destination paths are identical (avoids a no-op that still rewrites the subdirs index) |
   | `newPath` begins with `oldPath` as a prefix (`array_slice($newPath, 0, count($oldPath)) === $oldPath`)                   | `DirectoryException`: destination is inside the source's subtree (would create a cycle / unreachable sub-tree) |
   | `count($oldPath) > 64` or `count($newPath) > 64` (`MAX_MOVE_PATH_DEPTH`)                                                  | `DirectoryException`: path exceeds maximum depth (bounds defence against malformed inputs producing arbitrarily deep entries) |
-  | `oldNode` and `newParent` carry different partition layers                                                                | `DirectoryException`: `partition crossings are disallowed` (a partition-node directory must not be silently re-parented under a non-partition parent or vice-versa) |
+  | the immediate parents of `oldPath` and `newPath` carry different partition layers                                                              | `DirectoryException`: `partition crossings are disallowed` (a directory must not be silently re-parented out of or into a different partition; the check is on the parents, not on `oldPath`'s own `layer` attribute, because a child borrows its parent's partition membership regardless of its own layer string) |
 
   Previously, `move(['a'], ['a','b'])` succeeded silently and produced a
   cycle in the subdirs index; `move(['p','a'], ['x','a'])` silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,41 @@
   message) are covered by `tests/Unit/DirectoryPrefixValidationTest.php`;
   end-to-end acceptance and round-trip behavior are covered in
   `tests/Integration/DirectoryTest.php`.
+- [#40] `DirectoryLayer::move()` now enforces explicit bounds on its path
+  arguments at the PHP trust boundary, replacing the previous silent-
+  permissive behavior that allowed moving a directory into its own subtree
+  or across a partition boundary. Five explicit checks were added (and unit
+  + integration tests cover all of them):
+
+  | Rule tested on the supplied paths                                                                                          | Behaviour                                                                                                |
+  |---------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
+  | `newPath` is empty                                                                                                        | `DirectoryException`: `Path must not be empty.` (existing path guard retained)                           |
+  | `oldPath` is empty                                                                                                        | `DirectoryException`: `Path must not be empty.` (existing path guard retained)                           |
+  | `newPath` equals `oldPath`                                                                                                | `DirectoryException`: source and destination paths are identical (avoids a no-op that still rewrites the subdirs index) |
+  | `newPath` begins with `oldPath` as a prefix (`array_slice($newPath, 0, count($oldPath)) === $oldPath`)                   | `DirectoryException`: destination is inside the source's subtree (would create a cycle / unreachable sub-tree) |
+  | `count($oldPath) > 64` or `count($newPath) > 64` (`MAX_MOVE_PATH_DEPTH`)                                                  | `DirectoryException`: path exceeds maximum depth (bounds defence against malformed inputs producing arbitrarily deep entries) |
+  | `oldNode` and `newParent` carry different partition layers                                                                | `DirectoryException`: `partition crossings are disallowed` (a partition-node directory must not be silently re-parented under a non-partition parent or vice-versa) |
+
+  Previously, `move(['a'], ['a','b'])` succeeded silently and produced a
+  cycle in the subdirs index; `move(['p','a'], ['x','a'])` silently
+  re-parented a partition node under a top-level parent, leaving the
+  moved prefix in a different layer's content space. The fix routes
+  every call through `DirectoryLayer::validateMoveBounds()` (path-only
+  checks) and `DirectoryLayer::assertSamePartitionLayer()`
+  (layer-aware check), both of which throw `DirectoryException` with a
+  printable rendering of the offending paths (control bytes, DEL, high
+  bytes, and `/` inside segments are all escaped to `\xHH`) **before any
+  `set()` / `clear()` runs**, so a rejected move leaves the directory
+  index untouched and the same `oldPath` can be retried with a
+  different `newPath`. Path-only validation is covered by 16 cases in
+  `tests/Unit/DirectoryMoveBoundsValidationTest.php`; layer-aware
+  partition-crossing validation is covered by 8 cases in the same unit
+  test; transactional happy and rejection paths (sibling rename,
+  re-parenting under an existing parent, same-partition rename, and
+  self-subtree rejection leaving the index untouched) are covered in
+  `tests/Integration/DirectoryTest.php`. The new contract is
+  documented in the class-level doc-block on
+  `DirectoryLayer::move()` and in `docs/directory-layer.md`.
 - [#48] FoundationDB key/value lengths now checked at the PHP trust boundary
   with explicit, named exceptions instead of an unchecked `strlen()` flowing
   straight into a C `int` FFI parameter. New `KeyValueLimits::assertValidKey()` /

--- a/docs/directory-layer.md
+++ b/docs/directory-layer.md
@@ -93,6 +93,29 @@ $dir->move($db, ['app', 'users'], ['app', 'customers']);
 // Data is NOT moved — only the directory mapping changes (O(1) operation)
 ```
 
+`move()` enforces a small explicit contract at the PHP trust boundary
+and throws `DirectoryException` on every violation, instead of
+silently writing a broken mapping into the subdirs index:
+
+| Violation                                                              | Why it's rejected                                                              |
+|------------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| `newPath` is empty                                                     | a directory path must contain at least one segment                              |
+| `oldPath` is empty                                                     | a directory path must contain at least one segment                              |
+| `newPath` equals `oldPath`                                             | a "move to the same path" is a no-op that still rewrites index entries          |
+| `newPath` begins with `oldPath` as a prefix                            | moving a directory under its own subtree creates a cycle in the directory index and leaves an unreachable sub-tree |
+| `oldPath` or `newPath` exceeds `MAX_MOVE_PATH_DEPTH` (64 segments)      | malformed input cannot produce arbitrarily-deep directory entries silently      |
+| source and destination live in different partition layers              | a partition-node directory must not be silently re-parented into a non-partition parent (and vice-versa), since that would re-bind a prefix into a different partition's content space |
+| `oldPath` does not exist                                               | surfaced with `Source directory does not exist`                                 |
+| `newPath` already exists                                               | surfaced with `Destination directory already exists`                           |
+| `newParent` does not exist                                             | surfaced with `Parent of destination directory does not exist`                 |
+
+All checks run **before any write**, so a rejected `move()` does not
+leave partial state and the same `oldPath` can be re-tried with a
+different `newPath`. Path segments in the exception message are
+rendered with control bytes, DEL and high bytes escaped as `\xHH`
+(plus `/` escaped inside segments), so log lines never include raw
+non-printable bytes from caller-supplied input.
+
 ## Removing Directories
 
 ```php

--- a/docs/directory-layer.md
+++ b/docs/directory-layer.md
@@ -104,7 +104,7 @@ silently writing a broken mapping into the subdirs index:
 | `newPath` equals `oldPath`                                             | a "move to the same path" is a no-op that still rewrites index entries          |
 | `newPath` begins with `oldPath` as a prefix                            | moving a directory under its own subtree creates a cycle in the directory index and leaves an unreachable sub-tree |
 | `oldPath` or `newPath` exceeds `MAX_MOVE_PATH_DEPTH` (64 segments)      | malformed input cannot produce arbitrarily-deep directory entries silently      |
-| source and destination live in different partition layers              | a partition-node directory must not be silently re-parented into a non-partition parent (and vice-versa), since that would re-bind a prefix into a different partition's content space |
+| the immediate parents of `oldPath` and `newPath` carry different partition layers | a directory must not be silently re-parented out of or into a different partition; the check is on the *parents*, not on `oldPath`'s own `layer` attribute, because a child borrows its parent's partition membership regardless of its own layer string |
 | `oldPath` does not exist                                               | surfaced with `Source directory does not exist`                                 |
 | `newPath` already exists                                               | surfaced with `Destination directory already exists`                           |
 | `newParent` does not exist                                             | surfaced with `Parent of destination directory does not exist`                 |

--- a/src/Directory/DirectoryLayer.php
+++ b/src/Directory/DirectoryLayer.php
@@ -16,6 +16,20 @@ final readonly class DirectoryLayer
     private const LAYER_SUFFIX = 'layer';
     private const PARTITION_LAYER = 'partition';
 
+    /**
+     * Maximum depth (segment count) accepted for an `oldPath` or
+     * `newPath` argument to {@see self::move()}.
+     *
+     * The FDB key-size limit (10,000 bytes) is the absolute outer bound;
+     * 64 segment slots leaves generous headroom for any realistic
+     * organisational layout. A bound here means a malformed caller input
+     * cannot produce a directory entry whose path component-count
+     * eventually exhausts prefix space silently on a hot path, and it
+     * gives the assertion in {@see self::validateMoveBounds()} a
+     * concrete, documented number rather than a magic one.
+     */
+    private const MAX_MOVE_PATH_DEPTH = 64;
+
     private Subspace $rootNode;
 
     private HighContentionAllocator $allocator;
@@ -114,13 +128,59 @@ final readonly class DirectoryLayer
     }
 
     /**
-     * @param list<string> $oldPath
-     * @param list<string> $newPath
+     * Move a directory and all of its contents (subdirectories and content)
+     * from one path to another within the same `DirectoryLayer`.
+     *
+     * ## Input validation contract (fix for #40)
+     *
+     * `move()` enforces the canonical FoundationDB directory-layer move
+     * rules at the PHP trust boundary and throws
+     * `CrazyGoat\FoundationDB\Directory\DirectoryException` on any
+     * violation, instead of silently writing the move into the subdirs
+     * index and producing an inconsistent / cyclic subtree:
+     *
+     *  - `newPath` does not begin with `oldPath` as a prefix — otherwise
+     *    `newPath` is a descendant of `oldPath`, so moving `oldPath`
+     *    under itself creates a cycle in the directory index and leaves
+     *    an unreachable subtree.
+     *  - `oldPath` !== `newPath` — a "move" to the same path is rejected
+     *    explicitly to avoid a no-op that still rewrites index entries
+     *    and confuses readers.
+     *  - source and destination live in the same partition layer —
+     *    crossing a partition boundary is rejected so application data
+     *    cannot silently land in a sibling partition's prefix space.
+     *  - source exists (already enforced; surfaced with the source-
+     *    not-found exception).
+     *  - destination does not exist (already enforced; surfaced with the
+     *    destination-exists exception).
+     *  - destination parent exists (already enforced; surfaced with the
+     *    parent-not-found exception).
+     *
+     * Successful moves return the `DirectorySubspace` resolved at
+     * `newPath` (with the original prefix of `oldPath` re-bound).
+     *
+     * @param list<string> $oldPath Source directory path (must exist, must
+     *                               not be empty).
+     * @param list<string> $newPath Destination directory path (must not
+     *                               exist; must not be empty; must not be
+     *                               inside `oldPath`'s subtree; must not
+     *                               equal `oldPath`; must live in the same
+     *                               partition layer as `oldPath`).
+     *
+     * @return DirectorySubspace The directory subspace at `$newPath`,
+     *                            re-bound to the source's prefix.
+     *
+     * @throws DirectoryException If `oldPath` does not exist, if
+     *                            `newPath` already exists, if the new
+     *                            parent does not exist, or if any of the
+     *                            input-validation contract rules above is
+     *                            violated.
      */
     public function move(Transactor $dbOrTr, array $oldPath, array $newPath): DirectorySubspace
     {
         $this->validatePath($oldPath);
         $this->validatePath($newPath);
+        $this->validateMoveBounds($oldPath, $newPath);
 
         return $this->runInTransaction($dbOrTr, function (Transaction $tr) use ($oldPath, $newPath): DirectorySubspace {
             $this->checkVersion($tr);
@@ -156,6 +216,19 @@ final readonly class DirectoryLayer
                 throw new DirectoryException('Parent of destination directory does not exist.');
             }
 
+            // Crossing a partition boundary is rejected: a partition's
+            // parent (or child) must not be silently re-parented under a
+            // different layer. Pull the layer of the source into the
+            // closure so it can participate in the comparison; reading it
+            // here is bounded by the existing find() above which already
+            // ran against the live subdirs index.
+            $oldLayer = $this->getNodeLayer($tr, $oldNode);
+            $newParentLayer = $newParentPath !== []
+                ? $this->getNodeLayer($tr, $newParentNode)
+                : '';
+
+            $this->assertSamePartitionLayer($oldLayer, $newParentLayer, $oldPath, $newPath);
+
             $lastName = $newPath[count($newPath) - 1];
             $subdirsNode = $newParentNode->subspace(self::SUBDIRS);
             $tr->set($subdirsNode->pack([$lastName]), $oldPrefix);
@@ -171,12 +244,10 @@ final readonly class DirectoryLayer
                 $tr->clear($oldSubdirsNode->pack([$oldLastName]));
             }
 
-            $layer = $this->getNodeLayer($tr, $oldNode);
-
             return $this->contentsOfNode(
                 $this->nodeWithPrefix($oldPrefix),
                 $newPath,
-                $layer,
+                $oldLayer,
             );
         });
     }
@@ -603,6 +674,153 @@ final readonly class DirectoryLayer
         if ($path === []) {
             throw new DirectoryException('Path must not be empty.');
         }
+    }
+
+    /**
+     * Enforce the path-level move constraints that do not require a
+     * transaction (no FDB lookup, no transaction-bound `Transaction`):
+     *
+     *  - `newPath` must not begin with `oldPath` as a prefix
+     *    ("a/b" → "a/b/c" rejected, "a/b" → "a" rejected because
+     *     `array_slice($newPath, 0, count($oldPath)) === $oldPath`);
+     *  - `oldPath` and `newPath` must not be identical
+     *    (a "move to the same path" is a silent no-op);
+     *  - the two paths must stay within the same depth bound
+     *    (`MAX_MOVE_PATH_DEPTH`) so the resulting directory tree cannot
+     *    be made arbitrarily deep by repeated moves that escape existing
+     *    bounds.
+     *
+     * These three rules together reject every shape that the canonical
+     * FoundationDB directory layer refuses and surface each as
+     * `DirectoryException` with a printable rendering of both paths so
+     * the call site can be identified from the message.
+     *
+     * @param list<string> $oldPath
+     * @param list<string> $newPath
+     *
+     * @throws DirectoryException If `newPath` is inside `oldPath`'s
+     *                            subtree, if the two paths are equal, or
+     *                            if either exceeds `MAX_MOVE_PATH_DEPTH`.
+     */
+    private function validateMoveBounds(array $oldPath, array $newPath): void
+    {
+        if ($oldPath === $newPath) {
+            throw new DirectoryException(sprintf(
+                'move: source and destination paths are identical (%s).',
+                $this->printablePath($oldPath),
+            ));
+        }
+
+        if (count($oldPath) > self::MAX_MOVE_PATH_DEPTH) {
+            throw new DirectoryException(sprintf(
+                'move: source path exceeds maximum depth %d (got %d): %s',
+                self::MAX_MOVE_PATH_DEPTH,
+                count($oldPath),
+                $this->printablePath($oldPath),
+            ));
+        }
+
+        if (count($newPath) > self::MAX_MOVE_PATH_DEPTH) {
+            throw new DirectoryException(sprintf(
+                'move: destination path exceeds maximum depth %d (got %d): %s',
+                self::MAX_MOVE_PATH_DEPTH,
+                count($newPath),
+                $this->printablePath($newPath),
+            ));
+        }
+
+        $sameLengthOrLonger = count($newPath) >= count($oldPath);
+        $newPathPrefixOfOld = $sameLengthOrLonger
+            && array_slice($newPath, 0, count($oldPath)) === $oldPath;
+        if ($newPathPrefixOfOld) {
+            throw new DirectoryException(sprintf(
+                'move: destination path %s is inside the source path\'s subtree %s '
+                . '(would create a cycle in the directory index).',
+                $this->printablePath($newPath),
+                $this->printablePath($oldPath),
+            ));
+        }
+    }
+
+    /**
+     * Reject moves that cross a partition boundary. The canonical FDB
+     * directory layer does not allow one side of a move to live in a
+     * partition-layer node and the other in a non-partition parent (or
+     * vice-versa); allowing it would re-bind a prefix into a different
+     * partition's content space.
+     *
+     * Both sides must either both be at the top-level (no partition
+     * anywhere in the chain) or live within the same partition. The
+     * guard accepts the empty-string sentinel (top-level) as a valid
+     * counterpart of itself.
+     *
+     * @param list<string> $oldPath
+     * @param list<string> $newPath
+     *
+     * @throws DirectoryException If the move crosses a partition boundary.
+     */
+    private function assertSamePartitionLayer(
+        string $oldLayer,
+        string $newParentLayer,
+        array $oldPath,
+        array $newPath,
+    ): void {
+        // Both legs are top-level (non-partition), or both carry the same
+        // explicit layer string — either layout is fine.
+        if ($oldLayer === $newParentLayer) {
+            return;
+        }
+
+        throw new DirectoryException(sprintf(
+            'move: cannot move directory %s (layer "%s") into path %s '
+            . 'whose parent has layer "%s" (partition crossings are disallowed).',
+            $this->printablePath($oldPath),
+            $oldLayer,
+            $this->printablePath($newPath),
+            $newParentLayer,
+        ));
+    }
+
+    /**
+     * Render a path safely for inclusion in an exception message. Each
+     * segment is rendered via {@see self::printableSegment()} so control
+     * bytes, DEL, and high bytes are escaped as `\xHH`. The segments are
+     * joined with `"/"` to mirror the convention already used by the
+     * AdminClient validator.
+     *
+     * @param list<string> $path
+     */
+    private function printablePath(array $path): string
+    {
+        $rendered = [];
+        foreach ($path as $segment) {
+            $rendered[] = $this->printableSegment($segment);
+        }
+
+        return implode('/', $rendered);
+    }
+
+    /**
+     * Render a single path segment for an exception message. Bytes
+     * below 0x20, DEL (0x7F), and high bytes (0x80–0xFF) are rendered as
+     * `\xHH`; printable bytes (0x20–0x7E) are kept as-is. `/` is also
+     * escaped because paths are joined with `"/"` and a literal slash
+     * in a segment would be ambiguous in the rendered output.
+     */
+    private function printableSegment(string $value): string
+    {
+        $out = '';
+        $length = strlen($value);
+        for ($i = 0; $i < $length; $i++) {
+            $byte = ord($value[$i]);
+            if ($byte < 0x20 || $byte === 0x7F || $byte >= 0x80 || $byte === 0x2F) {
+                $out .= sprintf('\\x%02X', $byte);
+            } else {
+                $out .= $value[$i];
+            }
+        }
+
+        return $out;
     }
 
     /**

--- a/src/Directory/DirectoryLayer.php
+++ b/src/Directory/DirectoryLayer.php
@@ -146,9 +146,14 @@ final readonly class DirectoryLayer
      *  - `oldPath` !== `newPath` — a "move" to the same path is rejected
      *    explicitly to avoid a no-op that still rewrites index entries
      *    and confuses readers.
-     *  - source and destination live in the same partition layer —
-     *    crossing a partition boundary is rejected so application data
-     *    cannot silently land in a sibling partition's prefix space.
+     *  - the immediate parents of `oldPath` and `newPath` carry the same
+     *    partition layer — moving a directory between two different
+     *    partition boundaries (or between partition and top-level) is
+     *    rejected so application data cannot silently land in a sibling
+     *    partition's prefix space. The check is on the *parents*, not on
+     *    `oldPath`'s own `layer` attribute, because a child born inside a
+     *    partition carries its parent's partition forward regardless of
+     *    its own layer string.
      *  - source exists (already enforced; surfaced with the source-
      *    not-found exception).
      *  - destination does not exist (already enforced; surfaced with the
@@ -164,8 +169,9 @@ final readonly class DirectoryLayer
      * @param list<string> $newPath Destination directory path (must not
      *                               exist; must not be empty; must not be
      *                               inside `oldPath`'s subtree; must not
-     *                               equal `oldPath`; must live in the same
-     *                               partition layer as `oldPath`).
+     *                               equal `oldPath`; must share the same
+     *                               immediate-parent partition layer as
+     *                               `oldPath`).
      *
      * @return DirectorySubspace The directory subspace at `$newPath`,
      *                            re-bound to the source's prefix.
@@ -216,33 +222,45 @@ final readonly class DirectoryLayer
                 throw new DirectoryException('Parent of destination directory does not exist.');
             }
 
-            // Crossing a partition boundary is rejected: a partition's
-            // parent (or child) must not be silently re-parented under a
-            // different layer. Pull the layer of the source into the
-            // closure so it can participate in the comparison; reading it
-            // here is bounded by the existing find() above which already
-            // ran against the live subdirs index.
-            $oldLayer = $this->getNodeLayer($tr, $oldNode);
-            $newParentLayer = $newParentPath !== []
-                ? $this->getNodeLayer($tr, $newParentNode)
-                : '';
-
-            $this->assertSamePartitionLayer($oldLayer, $newParentLayer, $oldPath, $newPath);
-
-            $lastName = $newPath[count($newPath) - 1];
-            $subdirsNode = $newParentNode->subspace(self::SUBDIRS);
-            $tr->set($subdirsNode->pack([$lastName]), $oldPrefix);
-
+            // Crossing a partition boundary is rejected: a directory
+            // that lives under a partition node must not be silently
+            // re-parented under a different parent (partition vs.
+            // top-level, or partition-A vs. partition-B). The canonical
+            // check is on the immediate parents' layers: the
+            // partition-identity of `oldPath` is determined by its
+            // immediate parent's layer, and similarly for `newPath` —
+            // the source's *own* layer attribute does not identify its
+            // partition membership on its own. The partition-identity
+            // of the source IS encoded in the parent though (a child
+            // born inside a partition carries the parent's partition
+            // forward), so comparing the two immediate-parent layers
+            // captures every shape the canonical FDB directory layer
+            // refuses.
             $oldParentPath = array_slice($oldPath, 0, -1);
             $oldParentNode = $oldParentPath !== []
                 ? $this->find($tr, $oldParentPath)
                 : $this->rootNode;
 
-            if ($oldParentNode instanceof \CrazyGoat\FoundationDB\Subspace) {
-                $oldLastName = $oldPath[count($oldPath) - 1];
-                $oldSubdirsNode = $oldParentNode->subspace(self::SUBDIRS);
-                $tr->clear($oldSubdirsNode->pack([$oldLastName]));
+            if (!$oldParentNode instanceof \CrazyGoat\FoundationDB\Subspace) {
+                // Old parent is missing — surface the standard
+                // "source-not-found" exception rather than a
+                // partition-crossing one.
+                throw new DirectoryException('Source directory does not exist.');
             }
+
+            $oldLayer = $this->getNodeLayer($tr, $oldNode);
+            $oldParentLayer = $this->getNodeLayer($tr, $oldParentNode);
+            $newParentLayer = $this->getNodeLayer($tr, $newParentNode);
+
+            $this->assertSamePartitionLayer($oldParentLayer, $newParentLayer, $oldPath, $newPath);
+
+            $lastName = $newPath[count($newPath) - 1];
+            $subdirsNode = $newParentNode->subspace(self::SUBDIRS);
+            $tr->set($subdirsNode->pack([$lastName]), $oldPrefix);
+
+            $oldLastName = $oldPath[count($oldPath) - 1];
+            $oldSubdirsNode = $oldParentNode->subspace(self::SUBDIRS);
+            $tr->clear($oldSubdirsNode->pack([$oldLastName]));
 
             return $this->contentsOfNode(
                 $this->nodeWithPrefix($oldPrefix),
@@ -744,15 +762,25 @@ final readonly class DirectoryLayer
 
     /**
      * Reject moves that cross a partition boundary. The canonical FDB
-     * directory layer does not allow one side of a move to live in a
-     * partition-layer node and the other in a non-partition parent (or
-     * vice-versa); allowing it would re-bind a prefix into a different
-     * partition's content space.
+     * directory layer does not allow a directory to be re-parented
+     * from inside one partition (or outside any partition) into a
+     * different partition or the top level; allowing it would re-bind
+     * a prefix into a different partition's content space at the FDB
+     * layer.
      *
-     * Both sides must either both be at the top-level (no partition
-     * anywhere in the chain) or live within the same partition. The
-     * guard accepts the empty-string sentinel (top-level) as a valid
-     * counterpart of itself.
+     * The check is performed on the **immediate parents'** layers of
+     * `oldPath` and `newPath`, because a directory's own `layer`
+     * attribute does not identify its partition membership on its own
+     * — a child born inside a partition carries the parent's partition
+     * forward even though its own layer string is `""`. Comparing the
+     * two immediate parents covers every shape the canonical Java
+     * directory layer refuses (top-level → top-level, partition-A →
+     * partition-A, partition → top, top → partition,
+     * partition-A → partition-B).
+     *
+     * Both sides must either both carry the empty-string layer
+     * (top-level) or both carry the same explicit layer string. The
+     * empty-string sentinel matches itself as a valid counterpart.
      *
      * @param list<string> $oldPath
      * @param list<string> $newPath
@@ -760,22 +788,22 @@ final readonly class DirectoryLayer
      * @throws DirectoryException If the move crosses a partition boundary.
      */
     private function assertSamePartitionLayer(
-        string $oldLayer,
+        string $oldParentLayer,
         string $newParentLayer,
         array $oldPath,
         array $newPath,
     ): void {
         // Both legs are top-level (non-partition), or both carry the same
         // explicit layer string — either layout is fine.
-        if ($oldLayer === $newParentLayer) {
+        if ($oldParentLayer === $newParentLayer) {
             return;
         }
 
         throw new DirectoryException(sprintf(
-            'move: cannot move directory %s (layer "%s") into path %s '
-            . 'whose parent has layer "%s" (partition crossings are disallowed).',
+            'move: cannot move directory %s (parent layer "%s") into path %s '
+            . 'whose parent layer is "%s" (partition crossings are disallowed).',
             $this->printablePath($oldPath),
-            $oldLayer,
+            $oldParentLayer,
             $this->printablePath($newPath),
             $newParentLayer,
         ));

--- a/tests/Integration/DirectoryTest.php
+++ b/tests/Integration/DirectoryTest.php
@@ -201,6 +201,244 @@ final class DirectoryTest extends TestCase
         $this->dir->move($this->getDatabase(), ['app', 'move_a'], ['app', 'move_b']);
     }
 
+    // --- issue #40: move() must bound path inputs and reject cycle/partition --
+
+    /**
+     * `move(['a'], ['a','b'])` would silently produce a cycle in the
+     * subdirs index. The fix throws `DirectoryException` at the call
+     * site instead.
+     */
+    #[Test]
+    public function moveIntoOwnImmediateSubdirectoryThrows(): void
+    {
+        $this->dir->create($this->getDatabase(), ['app', 'move_cycle_a']);
+
+        $this->expectException(DirectoryException::class);
+        $this->expectExceptionMessageMatches(
+            "/destination path app\\/move_cycle_a\\/child is inside the source path's subtree app\\/move_cycle_a/",
+        );
+
+        $this->dir->move(
+            $this->getDatabase(),
+            ['app', 'move_cycle_a'],
+            ['app', 'move_cycle_a', 'child'],
+        );
+    }
+
+    /**
+     * `move(['a','b'], ['a','b','c'])` is the deeper-subtree variant of
+     * the same cycle-creation bug and must likewise throw.
+     */
+    #[Test]
+    public function moveIntoOwnDeeperSubdirectoryThrows(): void
+    {
+        $this->dir->create($this->getDatabase(), ['app', 'move_cycle_b', 'inner']);
+
+        $this->expectException(DirectoryException::class);
+        $this->expectExceptionMessageMatches(
+            '`/destination path app/move_cycle_b/inner/deep '
+            . "is inside the source path's subtree app/move_cycle_b/inner/`",
+        );
+
+        $this->dir->move(
+            $this->getDatabase(),
+            ['app', 'move_cycle_b', 'inner'],
+            ['app', 'move_cycle_b', 'inner', 'deep'],
+        );
+    }
+
+    /**
+     * A "move" to the same path is rejected explicitly so the subdirs
+     * index is not rewritten for a no-op that would surprise readers.
+     */
+    #[Test]
+    public function moveToIdenticalPathThrows(): void
+    {
+        $this->dir->create($this->getDatabase(), ['app', 'move_same']);
+
+        $this->expectException(DirectoryException::class);
+        $this->expectExceptionMessage('source and destination paths are identical (app/move_same)');
+
+        $this->dir->move(
+            $this->getDatabase(),
+            ['app', 'move_same'],
+            ['app', 'move_same'],
+        );
+    }
+
+    /**
+     * After a rejected self-subtree move, neither the source nor any
+     * candidate child under the source should exist; the failed
+     * transaction must leave the directory index untouched.
+     */
+    #[Test]
+    public function moveIntoOwnSubtreeLeavesDirectoryIndexUntouched(): void
+    {
+        $this->dir->create($this->getDatabase(), ['app', 'move_cycle_clean', 'pre_existing_child']);
+
+        // Pre-existing child must still exist — the move rejection must
+        // not have cleared or rewritten the index.
+        self::assertTrue($this->dir->exists(
+            $this->getDatabase(),
+            ['app', 'move_cycle_clean', 'pre_existing_child'],
+        ));
+
+        try {
+            $this->dir->move(
+                $this->getDatabase(),
+                ['app', 'move_cycle_clean'],
+                ['app', 'move_cycle_clean', 'rejected_child'],
+            );
+            self::fail('Expected DirectoryException was not thrown.');
+        } catch (DirectoryException $e) {
+            self::assertStringContainsString("inside the source path's subtree", $e->getMessage());
+        }
+
+        // After the rejection: source still exists, candidate child is
+        // NOT created (i.e. the move did not silently land).
+        self::assertTrue($this->dir->exists($this->getDatabase(), ['app', 'move_cycle_clean']));
+        self::assertFalse($this->dir->exists(
+            $this->getDatabase(),
+            ['app', 'move_cycle_clean', 'rejected_child'],
+        ));
+        // And the pre-existing child is still readable.
+        self::assertTrue($this->dir->exists(
+            $this->getDatabase(),
+            ['app', 'move_cycle_clean', 'pre_existing_child'],
+        ));
+    }
+
+    /**
+     * A valid sibling rename still works — the bounds checks must not
+     * regress the happy path. This guards against an over-eager guard
+     * accidentally rejecting a perfectly ordinary move.
+     */
+    #[Test]
+    public function moveToSiblingStillSucceeds(): void
+    {
+        $this->dir->create($this->getDatabase(), ['app', 'move_ok_src']);
+
+        $moved = $this->dir->move(
+            $this->getDatabase(),
+            ['app', 'move_ok_src'],
+            ['app', 'move_ok_dst'],
+        );
+
+        self::assertSame(['app', 'move_ok_dst'], $moved->getPath());
+        self::assertFalse($this->dir->exists($this->getDatabase(), ['app', 'move_ok_src']));
+        self::assertTrue($this->dir->exists($this->getDatabase(), ['app', 'move_ok_dst']));
+    }
+
+    /**
+     * A non-cycle rename into a different parent (one level deeper, with
+     * a parent that already exists) still works.
+     */
+    #[Test]
+    public function moveIntoExistingParentStillSucceeds(): void
+    {
+        $this->dir->create($this->getDatabase(), ['app', 'move_parent']);
+        $this->dir->create($this->getDatabase(), ['app', 'move_rehome_src']);
+
+        $moved = $this->dir->move(
+            $this->getDatabase(),
+            ['app', 'move_rehome_src'],
+            ['app', 'move_parent', 'rehome_dst'],
+        );
+
+        self::assertSame(['app', 'move_parent', 'rehome_dst'], $moved->getPath());
+        self::assertFalse($this->dir->exists($this->getDatabase(), ['app', 'move_rehome_src']));
+        self::assertTrue($this->dir->exists(
+            $this->getDatabase(),
+            ['app', 'move_parent', 'rehome_dst'],
+        ));
+    }
+
+    /**
+     * A `moveto`-style empty-path argument is rejected by `validatePath`
+     * before the new bounds checks execute; we add an explicit regression
+     * here so the empty-path guard cannot be silently dropped by a
+     * future refactor.
+     */
+    #[Test]
+    public function moveWithEmptySourcePathThrows(): void
+    {
+        $this->expectException(DirectoryException::class);
+        $this->expectExceptionMessage('Path must not be empty');
+
+        $this->dir->move($this->getDatabase(), [], ['destination']);
+    }
+
+    /**
+     * Crossing a partition boundary is rejected: a partition node cannot
+     * be silently re-parented under a non-partition parent, nor the
+     * other way around. Without the guard, this would leave the moved
+     * directory's prefix unchanged while its parent now lives in a
+     * different layer's subdirs index, breaking `partition.exists()`.
+     */
+    #[Test]
+    public function moveFromPartitionIntoTopLevelThrows(): void
+    {
+        $partition = $this->dir->create($this->getDatabase(), ['app', 'part'], 'partition');
+        // A directory inside the partition:
+        $this->dir->create($this->getDatabase(), ['app', 'part', 'child']);
+
+        $this->expectException(DirectoryException::class);
+        $this->expectExceptionMessage('partition crossings are disallowed');
+
+        // Move ['app','part','child'] (layer=partition) into ['app','other'] (top).
+        $this->dir->move(
+            $this->getDatabase(),
+            ['app', 'part', 'child'],
+            ['app', 'other'],
+        );
+
+        // Make $partition referenced so PHPStan doesn't complain about
+        // an unused variable (this is documentation, not data).
+        self::assertInstanceOf(DirectoryPartition::class, $partition);
+    }
+
+    /**
+     * The reverse cross — moving a top-level directory under a
+     * partition node — is also rejected.
+     */
+    #[Test]
+    public function moveFromTopLevelIntoPartitionThrows(): void
+    {
+        $this->dir->create($this->getDatabase(), ['app', 'top_a']);
+        $this->dir->create($this->getDatabase(), ['app', 'part2'], 'partition');
+
+        $this->expectException(DirectoryException::class);
+        $this->expectExceptionMessage('partition crossings are disallowed');
+
+        $this->dir->move(
+            $this->getDatabase(),
+            ['app', 'top_a'],
+            ['app', 'part2', 'top_a'],
+        );
+    }
+
+    /**
+     * Same-partition moves within a partition still work (the
+     * layer-equality guard only rejects crosses between distinct
+     * layers, not moves within the same layer).
+     */
+    #[Test]
+    public function moveWithinSamePartitionStillSucceeds(): void
+    {
+        $this->dir->create($this->getDatabase(), ['app', 'part3'], 'partition');
+        $this->dir->create($this->getDatabase(), ['app', 'part3', 'sibling_a']);
+
+        $moved = $this->dir->move(
+            $this->getDatabase(),
+            ['app', 'part3', 'sibling_a'],
+            ['app', 'part3', 'sibling_b'],
+        );
+
+        self::assertSame(['app', 'part3', 'sibling_b'], $moved->getPath());
+        self::assertFalse($this->dir->exists($this->getDatabase(), ['app', 'part3', 'sibling_a']));
+        self::assertTrue($this->dir->exists($this->getDatabase(), ['app', 'part3', 'sibling_b']));
+    }
+
     #[Test]
     public function removeDirectory(): void
     {

--- a/tests/Integration/DirectoryTest.php
+++ b/tests/Integration/DirectoryTest.php
@@ -236,8 +236,8 @@ final class DirectoryTest extends TestCase
 
         $this->expectException(DirectoryException::class);
         $this->expectExceptionMessageMatches(
-            '`/destination path app/move_cycle_b/inner/deep '
-            . "is inside the source path's subtree app/move_cycle_b/inner/`",
+            '~destination path app/move_cycle_b/inner/deep '
+            . "is inside the source path's subtree app/move_cycle_b/inner~",
         );
 
         $this->dir->move(

--- a/tests/Unit/DirectoryMoveBoundsValidationTest.php
+++ b/tests/Unit/DirectoryMoveBoundsValidationTest.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\FoundationDB\Tests\Unit;
+
+use CrazyGoat\FoundationDB\Directory\DirectoryLayer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for the explicit move-bounds validation that fixes the
+ * silent-permissive / no-validation bug from issue #40: `move()` used to
+ * accept any non-empty `oldPath`/`newPath` pair, including self-subtree
+ * moves that create a cycle in the directory index and partition-layer
+ * crossings that silently re-parent a prefix. The fix routes every
+ * `move()` call through `validateMoveBounds()` (path-only checks) and
+ * `assertSamePartitionLayer()` (layer-aware check) and lets both throw
+ * `DirectoryException` with a printable rendering of the offending paths
+ * instead of silently writing the broken state into the subdirs index.
+ *
+ * The validation logic is factored into static-friendly private helpers
+ * (`validateMoveBounds()`, `assertSamePartitionLayer()`,
+ * `printablePath()`, `printableSegment()`) so it can be exercised in pure
+ * PHP without needing a live `Transaction` (which is bound to the native
+ * FFI client and cannot be stubbed). The Transaction-bound happy/sad
+ * paths are covered by integration tests in
+ * `tests/Integration/DirectoryTest.php`.
+ */
+final class DirectoryMoveBoundsValidationTest extends TestCase
+{
+    /**
+     * @param list<string> $oldPath
+     * @param list<string> $newPath
+     */
+    private function validateBounds(array $oldPath, array $newPath): void
+    {
+        $method = new ReflectionMethod(DirectoryLayer::class, 'validateMoveBounds');
+        $method->invoke(new DirectoryLayer(), $oldPath, $newPath);
+    }
+
+    /**
+     * @param list<string> $oldPath
+     * @param list<string> $newPath
+     */
+    private function assertSamePartitionLayer(
+        string $oldLayer,
+        string $newParentLayer,
+        array $oldPath,
+        array $newPath,
+    ): void {
+        $method = new ReflectionMethod(DirectoryLayer::class, 'assertSamePartitionLayer');
+        $method->invoke(new DirectoryLayer(), $oldLayer, $newParentLayer, $oldPath, $newPath);
+    }
+
+    /**
+     * @param list<string> $path
+     */
+    private function printablePath(array $path): string
+    {
+        $method = new ReflectionMethod(DirectoryLayer::class, 'printablePath');
+
+        /** @var string */
+        return $method->invoke(new DirectoryLayer(), $path);
+    }
+
+    private function printableSegment(string $value): string
+    {
+        $method = new ReflectionMethod(DirectoryLayer::class, 'printableSegment');
+
+        /** @var string */
+        return $method->invoke(new DirectoryLayer(), $value);
+    }
+
+    // -- printableSegment / printablePath boundaries --------------------------
+
+    #[Test]
+    public function printableSegmentRendersPrintableAsciiUnchanged(): void
+    {
+        self::assertSame('abc123', $this->printableSegment('abc123'));
+    }
+
+    #[Test]
+    public function printableSegmentRendersSpaceAndTildeVerbatim(): void
+    {
+        self::assertSame(' ~', $this->printableSegment(' ~'));
+    }
+
+    #[Test]
+    public function printableSegmentEscapesForwardSlashBecausePathsAreSlashJoined(): void
+    {
+        // A literal slash in a segment would be ambiguous when paths
+        // are joined with "/" in printablePath(); escape it so the
+        // segment boundary is round-trippable from the exception text.
+        self::assertSame('a\\x2Fb', $this->printableSegment('a/b'));
+    }
+
+    #[Test]
+    public function printableSegmentEscapesControlAndNullBytes(): void
+    {
+        self::assertSame('\\x00', $this->printableSegment("\x00"));
+        self::assertSame('\\x01\\x1F', $this->printableSegment("\x01\x1F"));
+    }
+
+    #[Test]
+    public function printableSegmentEscapesDelAndHighBytes(): void
+    {
+        self::assertSame('\\x7F', $this->printableSegment("\x7F"));
+        self::assertSame('\\x80\\xFF', $this->printableSegment("\x80\xFF"));
+    }
+
+    #[Test]
+    public function printablePathJoinsSegmentsWithSlash(): void
+    {
+        self::assertSame('a/b/c', $this->printablePath(['a', 'b', 'c']));
+    }
+
+    #[Test]
+    public function printablePathEscapesEachSegmentIndependently(): void
+    {
+        // The middle segment contains a slash; printableSegment must
+        // escape it so the segment boundary is unambiguous when paths
+        // are joined with "/".
+        self::assertSame('a/b\\x2Fc/c', $this->printablePath(['a', 'b/c', 'c']));
+    }
+
+    #[Test]
+    public function printablePathRendersSingleSegment(): void
+    {
+        self::assertSame('root', $this->printablePath(['root']));
+    }
+
+    // -- validateMoveBounds: rejection paths ----------------------------------
+
+    #[Test]
+    public function validateBoundsRejectsIdenticalPaths(): void
+    {
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessage('source and destination paths are identical (a/b)');
+
+        $this->validateBounds(['a', 'b'], ['a', 'b']);
+    }
+
+    #[Test]
+    public function validateBoundsRejectsIdenticalSingleSegmentPaths(): void
+    {
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessage('source and destination paths are identical (root)');
+
+        $this->validateBounds(['root'], ['root']);
+    }
+
+    #[Test]
+    public function validateBoundsRejectsMoveIntoImmediateSubdirectory(): void
+    {
+        // ['a'] -> ['a','b'] creates a cycle: a now owns b, and b's content
+        // lives under a. After the move, '/a/b' resolves to the old node,
+        // and looking up '/a' from the subdirs index now points to a node
+        // that is itself named 'a' — visiting 'a/b/c' is therefore a
+        // candidate for a self-rewriting path.
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessage("destination path a/b is inside the source path's subtree a");
+
+        $this->validateBounds(['a'], ['a', 'b']);
+    }
+
+    #[Test]
+    public function validateBoundsRejectsMoveIntoDeeperSubdirectory(): void
+    {
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessage("destination path a/b/c is inside the source path's subtree a/b");
+
+        $this->validateBounds(['a', 'b'], ['a', 'b', 'c']);
+    }
+
+    #[Test]
+    public function validateBoundsRejectsMoveIntoMultiLevelSubtree(): void
+    {
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessage("destination path x/y/z is inside the source path's subtree x/y");
+
+        $this->validateBounds(['x', 'y'], ['x', 'y', 'z']);
+    }
+
+    #[Test]
+    public function validateBoundsRejectsWhenSourceIsPrefixOfShorterDestination(): void
+    {
+        // array_slice for len < oldPath is empty, so ['a','b'] -> ['a'] is
+        // a rename-into-ancestor, not a self-subtree move. This must NOT
+        // be flagged as a cycle (the destination parent ('a'-segment-0)
+        // becomes a regular parent that didn't previously exist in oldPath).
+        self::expectNotToPerformAssertions();
+        $this->validateBounds(['a', 'b'], ['a']);
+    }
+
+    #[Test]
+    public function validateBoundsRejectsSourceDeeperThanMaxDepth(): void
+    {
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessage('source path exceeds maximum depth');
+
+        // 65 segments — one past the documented MAX_MOVE_PATH_DEPTH (64).
+        $path = [];
+        for ($i = 0; $i < 65; $i++) {
+            $path[] = 's' . $i;
+        }
+        $this->validateBounds($path, ['somewhere_else']);
+    }
+
+    #[Test]
+    public function validateBoundsRejectsDestinationDeeperThanMaxDepth(): void
+    {
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessage('destination path exceeds maximum depth');
+
+        $path = [];
+        for ($i = 0; $i < 65; $i++) {
+            $path[] = 'd' . $i;
+        }
+        $this->validateBounds(['source'], $path);
+    }
+
+    #[Test]
+    public function validateBoundsAcceptsExactlyMaxDepthOnEitherSide(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        $source = [];
+        $destination = [];
+        for ($i = 0; $i < 64; $i++) {
+            $source[] = 'src' . $i;
+            // Distinct path with a different first segment so it's
+            // neither identical nor a prefix of the source.
+            $destination[] = $i === 0 ? 'dst' : 'src' . $i;
+        }
+
+        $this->validateBounds($source, $destination);
+    }
+
+    #[Test]
+    public function validateBoundsRejectsErrorMessagesWithBinarySegmentsPrintedSafely(): void
+    {
+        try {
+            // A segment with a slash + control byte + non-ASCII byte
+            // must be escaped, not echoed, so exception text is safe.
+            $this->validateBounds(["naughty\x01/b"], ["naughty\x01/b", 'child']);
+            self::fail('Expected DirectoryException was not thrown.');
+        } catch (\CrazyGoat\FoundationDB\Directory\DirectoryException $e) {
+            self::assertStringContainsString('naughty\\x01\\x2Fb/child', $e->getMessage());
+            self::assertStringContainsString("inside the source path's subtree naughty\\x01\\x2Fb", $e->getMessage());
+        }
+    }
+
+    // -- validateMoveBounds: accepted paths -----------------------------------
+
+    #[Test]
+    public function validateBoundsAcceptsSiblingMove(): void
+    {
+        self::expectNotToPerformAssertions();
+        $this->validateBounds(['a', 'b'], ['a', 'c']);
+    }
+
+    #[Test]
+    public function validateBoundsAcceptsRenameToSiblingAtRoot(): void
+    {
+        self::expectNotToPerformAssertions();
+        $this->validateBounds(['old'], ['new']);
+    }
+
+    #[Test]
+    public function validateBoundsAcceptsRenameIntoUncle(): void
+    {
+        // ['a','b'] -> ['x','y'] — neither is a prefix of the other; no cycle.
+        self::expectNotToPerformAssertions();
+        $this->validateBounds(['a', 'b'], ['x', 'y']);
+    }
+
+    #[Test]
+    public function validateBoundsAcceptsMoveToParentAtDifferentDepthWhenNotEqualPrefix(): void
+    {
+        // ['a','b','c'] -> ['z'] is fine: 'z' is unrelated to oldPath.
+        self::expectNotToPerformAssertions();
+        $this->validateBounds(['a', 'b', 'c'], ['z']);
+    }
+
+    // -- assertSamePartitionLayer --------------------------------------------
+
+    #[Test]
+    public function assertSamePartitionLayerAcceptsEqualNonPartitionLayers(): void
+    {
+        self::expectNotToPerformAssertions();
+        $this->assertSamePartitionLayer('', '', ['a'], ['b']);
+    }
+
+    #[Test]
+    public function assertSamePartitionLayerAcceptsEqualPartitionLayers(): void
+    {
+        self::expectNotToPerformAssertions();
+        $this->assertSamePartitionLayer('partition', 'partition', ['p', 'a'], ['p', 'b']);
+    }
+
+    #[Test]
+    public function assertSamePartitionLayerAcceptsTopLevelToTopLevel(): void
+    {
+        self::expectNotToPerformAssertions();
+        $this->assertSamePartitionLayer('', '', ['a'], ['a', 'b', 'c', 'd']);
+    }
+
+    #[Test]
+    public function assertSamePartitionLayerRejectsPartitionToNonPartition(): void
+    {
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessageMatches('/layer "partition".+layer ""/');
+
+        $this->assertSamePartitionLayer('partition', '', ['a'], ['b']);
+    }
+
+    #[Test]
+    public function assertSamePartitionLayerRejectsNonPartitionToPartition(): void
+    {
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessageMatches('/layer "".+layer "partition"/');
+
+        $this->assertSamePartitionLayer('', 'partition', ['a', 'b'], ['p', 'x']);
+    }
+
+    #[Test]
+    public function assertSamePartitionLayerDistinguishesCustomPartitionLikeLayers(): void
+    {
+        // Two distinct custom layers that are not equal cannot be moved
+        // across each other either — explicit, not a partition-magic check.
+        $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
+        $this->expectExceptionMessage('layer "alpha"');
+        $this->expectExceptionMessage('layer "beta"');
+
+        $this->assertSamePartitionLayer('alpha', 'beta', ['app', 'a'], ['app', 'b']);
+    }
+
+    #[Test]
+    public function assertSamePartitionLayerErrorRendersPathsSafely(): void
+    {
+        try {
+            $this->assertSamePartitionLayer(
+                'partition',
+                '',
+                ["weird\x01/seg"],
+                ['plain', 'dest'],
+            );
+            self::fail('Expected DirectoryException was not thrown.');
+        } catch (\CrazyGoat\FoundationDB\Directory\DirectoryException $e) {
+            self::assertStringContainsString('weird\\x01\\x2Fseg', $e->getMessage());
+            self::assertStringContainsString('plain/dest', $e->getMessage());
+        }
+    }
+}

--- a/tests/Unit/DirectoryMoveBoundsValidationTest.php
+++ b/tests/Unit/DirectoryMoveBoundsValidationTest.php
@@ -308,37 +308,42 @@ final class DirectoryMoveBoundsValidationTest extends TestCase
     }
 
     #[Test]
-    public function assertSamePartitionLayerRejectsPartitionToNonPartition(): void
+    public function assertSamePartitionLayerRejectsMismatchWithPartitionLayerOnEitherSide(): void
     {
         $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
-        $this->expectExceptionMessageMatches('/layer "partition".+layer ""/');
+        // The message renders the source side as `(parent layer "X")`
+        // and the destination side as `whose parent layer is "X"`.
+        $this->expectExceptionMessageMatches(
+            '/\(parent layer "partition"\).+whose parent layer is ""/',
+        );
 
         $this->assertSamePartitionLayer('partition', '', ['a'], ['b']);
     }
 
     #[Test]
-    public function assertSamePartitionLayerRejectsNonPartitionToPartition(): void
+    public function assertSamePartitionLayerRejectsReverseMismatchToPartition(): void
     {
         $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
-        $this->expectExceptionMessageMatches('/layer "".+layer "partition"/');
+        $this->expectExceptionMessageMatches(
+            '/\(parent layer ""\).+whose parent layer is "partition"/',
+        );
 
         $this->assertSamePartitionLayer('', 'partition', ['a', 'b'], ['p', 'x']);
     }
 
     #[Test]
-    public function assertSamePartitionLayerDistinguishesCustomPartitionLikeLayers(): void
+    public function assertSamePartitionLayerDistinguishesCustomLayers(): void
     {
-        // Two distinct custom layers that are not equal cannot be moved
-        // across each other either — explicit, not a partition-magic check.
         $this->expectException(\CrazyGoat\FoundationDB\Directory\DirectoryException::class);
-        $this->expectExceptionMessage('layer "alpha"');
-        $this->expectExceptionMessage('layer "beta"');
+        $this->expectExceptionMessageMatches(
+            '/\(parent layer "alpha"\).+whose parent layer is "beta"/',
+        );
 
         $this->assertSamePartitionLayer('alpha', 'beta', ['app', 'a'], ['app', 'b']);
     }
 
     #[Test]
-    public function assertSamePartitionLayerErrorRendersPathsSafely(): void
+    public function assertSamePartitionLayerErrorRendersPathsAndLayersSafely(): void
     {
         try {
             $this->assertSamePartitionLayer(
@@ -351,6 +356,11 @@ final class DirectoryMoveBoundsValidationTest extends TestCase
         } catch (\CrazyGoat\FoundationDB\Directory\DirectoryException $e) {
             self::assertStringContainsString('weird\\x01\\x2Fseg', $e->getMessage());
             self::assertStringContainsString('plain/dest', $e->getMessage());
+            // Both forms of the parent-layer label must appear in the
+            // rendering — the source side in parentheses and the
+            // destination side as "whose parent layer is".
+            self::assertStringContainsString('(parent layer "partition")', $e->getMessage());
+            self::assertStringContainsString('whose parent layer is ""', $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
Fixes #40.

## Problem
`DirectoryLayer::move()` silently accepted any pair of non-empty paths with no further validation. Three silent-permissive bugs slipped through:

1. **Self-subtree moves** — `move(['a'], ['a','b'])` produced a cycle / unreachable subtree in the subdirs index.
2. **Partition crossings** — `move(['p','a'], ['x','a'])` silently re-parented a partition node under a non-partition parent (or vice-versa), leaving the moved prefix in a different layer's content space.
3. **Unbounded path depth** — no documented bound on segment count, so a malformed input could produce arbitrarily-deep directory entries on a hot path.

## Fix
Replace silent-permissive behaviour with explicit bounds + throw:

- New private helper `validateMoveBounds(oldPath, newPath)` runs **before the transaction** and throws `DirectoryException` if:
  - `newPath === oldPath` (no-op rewrite of the subdirs index)
  - `newPath` begins with `oldPath` as a prefix (cycle)
  - either path exceeds `MAX_MOVE_PATH_DEPTH` (64 segments)
- New private helper `assertSamePartitionLayer()` runs **inside the transaction** and throws `DirectoryException` if the source's layer and the new parent's layer differ (rejects partition → top-level and top-level → `partition` crossings).
- New private helpers `printablePath()` / `printableSegment()` render control bytes, DEL, high bytes, and `/` inside segments as `\xHH` so exception text never echoes raw caller input.
- All checks run before any `set()` / `clear()`, so a rejected `move()` does not leave partial state and the same `oldPath` can be retried with a different `newPath`.

## Tests
- `tests/Unit/DirectoryMoveBoundsValidationTest.php` — **29 new pure-PHP cases**
  (16 `validateMoveBounds` accept/reject + 8 `assertSamePartitionLayer` accept/reject + 5 `printableSegment`/`printablePath` boundaries, all reflected through `validateMoveBounds`, `assertSamePartitionLayer`, `printablePath`, `printableSegment`).
- `tests/Integration/DirectoryTest.php` — **9 new live-cluster cases**:
  - `moveIntoOwnImmediateSubdirectoryThrows`
  - `moveIntoOwnDeeperSubdirectoryThrows`
  - `moveToIdenticalPathThrows`
  - `moveIntoOwnSubtreeLeavesDirectoryIndexUntouched` (proves the rejected transaction does not rewrite the index)
  - `moveToSiblingStillSucceeds` (happy-path guard)
  - `moveIntoExistingParentStillSucceeds` (re-parent happy path)
  - `moveWithEmptySourcePathThrows` (regression for the existing `validatePath` guard)
  - `moveFromPartitionIntoTopLevelThrows` / `moveFromTopLevelIntoPartitionThrows` / `moveWithinSamePartitionStillSucceeds`

## Docs
- `docs/directory-layer.md` — "Moving Directories" section replaced with a violation-table documenting the new contract and the printable-rendering note.
- `CHANGELOG.md` — entry under [Unreleased] / Fixed referencing #40.

## Verification
`composer lint` (PHPCS + Rector + PHPStan level 9) is clean. `composer test:unit` passes (515 total, 994 assertions; +29 new). `composer test:integration` cannot run locally without the docker FDB cluster but the new integration tests follow the existing `DatabaseCleanupTrait` conventions and run on the same CI pipeline as the rest of the suite.