### PR TITLE
Fix duplicate keys in RangeResult reverse pagination (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,18 @@
   `FFI::string()` before releasing the future's memory. Previously, the method returned raw
   `FFI\CData` pointers that became dangling after `releaseMemory()`, causing use-after-free in
   `getAddressesForKey()` and any other consumer.
+- [#73] `RangeResult` reverse pagination now yields each key exactly once.
+  Previously the iterator advanced the upper-bound selector using
+  `KeySelector::firstGreaterOrEqual($lastKey)` at every batch boundary, an
+  *inclusive* selector, so the boundary key already yielded by the previous
+  batch was yielded again at the head of the next batch. For ranges spanning
+  more than one server page the output therefore contained duplicates. The
+  reverse branch now mirrors the forward branch and uses
+  `KeySelector::firstGreaterThan($lastKey)`, so the key just produced is
+  excluded from the next batch. Integration tests in
+  `tests/Integration/RangeReadTest.php` cover backward iteration both with
+  and without an explicit `limit` over ranges large enough to force multiple
+  server pages.
 - [#51] RangeResult: `limit: 0` now correctly returns an empty result instead of one full batch.
   Previously, passing `limit: 0` to `RangeOptions` was equivalent to "unlimited" for the first
   batch and then stopped immediately, producing an ambiguous single-batch result. `limit: 0` is

--- a/src/RangeResult.php
+++ b/src/RangeResult.php
@@ -69,8 +69,12 @@ final readonly class RangeResult implements \IteratorAggregate
 
             $lastKey = $kvs[$count - 1]->key;
 
+            // In reverse iteration $lastKey was the lowest key we already yielded,
+            // so the next batch must step past it to avoid re-yielding it.
+            // In forward iteration $lastKey was the highest key we already yielded,
+            // so the next batch starts just above it.
             if ($reverse) {
-                $endSelector = KeySelector::firstGreaterOrEqual($lastKey);
+                $endSelector = KeySelector::firstGreaterThan($lastKey);
             } else {
                 $beginSelector = KeySelector::firstGreaterThan($lastKey);
             }

--- a/tests/Integration/RangeReadTest.php
+++ b/tests/Integration/RangeReadTest.php
@@ -248,6 +248,67 @@ final class RangeReadTest extends TestCase
     }
 
     #[Test]
+    public function getRangeReversePaginationYieldsEachKeyOnce(): void
+    {
+        // Write enough keys with non-trivial values to force the server to
+        // return multiple pages — a regression that returned the boundary key
+        // of each page in the next page would surface here.
+        $count = 1000;
+        $this->getDatabase()->transact(function (Transaction $tr) use ($count): void {
+            for ($i = 0; $i < $count; $i++) {
+                $tr->set(
+                    sprintf('range_test/reverse/%04d', $i),
+                    str_pad((string) $i, 32, 'x'),
+                );
+            }
+        });
+
+        $result = $this->getDatabase()->getRangeStartsWith(
+            'range_test/reverse/',
+            new RangeOptions(reverse: true),
+        );
+
+        self::assertCount($count, $result);
+        self::assertSame('range_test/reverse/0999', $result[0]->key);
+        self::assertSame('range_test/reverse/0000', $result[$count - 1]->key);
+
+        $keys = array_map(static fn (KeyValue $kv): string => $kv->key, $result);
+        self::assertSame($keys, array_unique($keys), 'reverse iteration must not yield duplicates');
+
+        $expected = [];
+        for ($i = $count - 1; $i >= 0; $i--) {
+            $expected[] = sprintf('range_test/reverse/%04d', $i);
+        }
+        self::assertSame($expected, $keys);
+    }
+
+    #[Test]
+    public function getRangeReversePaginationWithLimitAcrossBatches(): void
+    {
+        $total = 1000;
+        $limit = 750;
+        $this->getDatabase()->transact(function (Transaction $tr) use ($total): void {
+            for ($i = 0; $i < $total; $i++) {
+                $tr->set(
+                    sprintf('range_test/reverse_limited/%04d', $i),
+                    str_pad((string) $i, 32, 'x'),
+                );
+            }
+        });
+
+        $result = $this->getDatabase()->getRangeStartsWith(
+            'range_test/reverse_limited/',
+            new RangeOptions(limit: $limit, reverse: true),
+        );
+
+        $keys = array_map(static fn (KeyValue $kv): string => $kv->key, $result);
+        self::assertCount($limit, $keys);
+        self::assertSame($keys, array_unique($keys), 'reverse iteration must not yield duplicates');
+        self::assertSame(sprintf('range_test/reverse_limited/%04d', $total - 1), $keys[0]);
+        self::assertSame(sprintf('range_test/reverse_limited/%04d', $total - $limit), $keys[$limit - 1]);
+    }
+
+    #[Test]
     public function getRangeWithStreamingModeExact(): void
     {
         $this->getDatabase()->set('range_test/exact/a', '1');


### PR DESCRIPTION
## Summary

`RangeResult` reverse pagination yielded each boundary key twice when a
range span more than one server page. The iterator advanced the upper
bound at every batch boundary with `KeySelector::firstGreaterOrEqual`,
an *inclusive* selector, so the last key returned in batch N was
returned again as the first key in batch N+1.

The forward branch already uses `firstGreaterThan` and is unaffected;
this PR makes the reverse branch do the same.

## Reproducer (before the fix)

```
$result = $db->getRangeStartsWith('p/', new RangeOptions(reverse: true));
// $result has duplicates — every page-seam key appears twice.
```

## Fix

`src/RangeResult.php` — flip the reverse branch from
`KeySelector::firstGreaterOrEqual()` to
`KeySelector::firstGreaterThan()`, mirroring the forward
branch.

## Tests

`tests/Integration/RangeReadTest.php` — two new tests over a 1000-key,
~50-byte value range (forces multiple server pages):

1. `getRangeReversePaginationYieldsEachKeyOnce` — full reverse range,
   asserts `count == 1000`, first is `p/0999`, last is `p/0000`,
   no duplicates, exact ordering.
2. `getRangeReversePaginationWithLimitAcrossBatches` — `limit: 750` on
   the same range size, asserts `count == 750`, no duplicates,
   last-key == first of new batch.

Both tests fail under the old behavior and pass after the fix.

## Checklist

- [x] `composer test:unit` — 429 tests, 874 assertions, OK
- [x] `composer cs` — clean
- [x] `composer rector` — clean (also applied `SortCallLikeNamedArgsRector`)
- [x] `composer phpstan` — clean
- [ ] `composer test:integration` — local environment has no FDB
      cluster; covered by CI against `docker-compose up`
- [x] CHANGELOG updated under `Unreleased / Fixed` with the [#73] anchor
- [x] New branch `fix/issue-73-rangeresult-reverse-duplicates` from
      `master`