### PR TITLE
fix(#71): align getClientStatus return type with getClusterStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,3 +131,13 @@
   `\InvalidArgumentException` immediately at the offending call;
   wire bytes that round-trip just at the limit are still accepted,
   so legitimate deeply-nested user data is unaffected.
+
+### Added
+- [#71] `Database::getClientStatus()` now accepts an optional `bool $asArray = false`
+  parameter. When `true`, it returns the decoded status as an
+  `array<string, mixed>`, making its return type consistent with
+  `AdminClient::getClusterStatus()`. The default (`false`) preserves the
+  previous raw-JSON-string return type, so the change is fully
+  backward-compatible. `tests/Integration/DatabaseMonitoringTest.php` adds a
+  test asserting the parsed array form, and `tests/Integration/RebootWorkerTest.php`
+  now consumes the array form directly instead of manually decoding JSON.

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ $readable = KeyUtil::printable("\x00\x01\xFF");  // '\x00\x01\xff'
 ```php
 $busyness = $db->getMainThreadBusyness(); // 0.0 to 1.0
 $status = $db->getClientStatus();          // JSON string
+$statusArray = $db->getClientStatus(asArray: true); // parsed array, consistent with AdminClient::getClusterStatus()
 ```
 
 ### Locality API

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -52,6 +52,9 @@ echo "Thread busyness: " . round($busyness * 100, 1) . "%\n";
 // Client status (JSON string)
 $statusJson = $db->getClientStatus();
 $status = json_decode($statusJson, true);
+
+// Or get the parsed array directly (consistent with AdminClient::getClusterStatus())
+$status = $db->getClientStatus(asArray: true);
 ```
 
 ## Connection Strings

--- a/src/Database.php
+++ b/src/Database.php
@@ -357,14 +357,32 @@ final class Database implements Transactor, ReadTransactor
         return $busyness;
     }
 
-    public function getClientStatus(): string
+    /**
+     * Get the client status of the database.
+     *
+     * @param bool $asArray When true, returns the decoded status as an associative array,
+     *                      matching the return type of AdminClient::getClusterStatus().
+     * @return ($asArray is true ? array<string, mixed> : string)
+     * @throws FDBException If status retrieval fails
+     * @throws \JsonException If $asArray is true and the status JSON cannot be decoded
+     */
+    public function getClientStatus(bool $asArray = false): string|array
     {
         $future = new Future\FutureKey(
             $this->client->fdb->fdb_database_get_client_status($this->dpointer),
             $this->client,
         );
 
-        return $future->await();
+        $status = $future->await();
+
+        if ($asArray) {
+            /** @var array<string, mixed> $decoded */
+            $decoded = json_decode($status, true, 512, JSON_THROW_ON_ERROR);
+
+            return $decoded;
+        }
+
+        return $status;
     }
 
     /**

--- a/tests/Integration/DatabaseMonitoringTest.php
+++ b/tests/Integration/DatabaseMonitoringTest.php
@@ -28,4 +28,12 @@ final class DatabaseMonitoringTest extends TestCase
         $decoded = json_decode($status, true);
         self::assertIsArray($decoded);
     }
+
+    #[Test]
+    public function getClientStatusCanReturnParsedArray(): void
+    {
+        $status = $this->getDatabase()->getClientStatus(asArray: true);
+
+        self::assertNotEmpty($status);
+    }
 }

--- a/tests/Integration/RebootWorkerTest.php
+++ b/tests/Integration/RebootWorkerTest.php
@@ -40,9 +40,8 @@ final class RebootWorkerTest extends TestCase
         $db = $this->getDatabase();
 
         // Get cluster status to find a storage node address
-        $status = $db->getClientStatus();
         /** @var array<string, mixed> $statusData */
-        $statusData = json_decode($status, true);
+        $statusData = $db->getClientStatus(asArray: true);
 
         // Find a storage node address from the status
         $storageAddress = null;


### PR DESCRIPTION
## Summary

Closes #71

`Database::getClientStatus()` returned a raw JSON string while `AdminClient::getClusterStatus()` returned a parsed array, forcing callers to remember which method returns which format.

This adds an optional `bool $asArray = false` parameter to `Database::getClientStatus()`. When `true`, it returns the decoded status as `array<string, mixed>`, matching `getClusterStatus()`. The default (`false`) preserves the previous raw-JSON-string return type, so the change is fully backward-compatible.

## Changes
- `src/Database.php`: add optional `$asArray` param (conditional return type via PHPStan generics).
- `tests/Integration/DatabaseMonitoringTest.php`: add test for the parsed-array form.
- `tests/Integration/RebootWorkerTest.php`: consume the array form directly.
- `README.md`, `docs/advanced.md`, `CHANGELOG.md`: document the new option.

## Verification
- `composer lint` passes (PHPCS + Rector dry-run + PHPStan).
- `composer test:unit` passes (3 GMP-related failures are pre-existing, caused by the GMP extension not being loaded in this local environment; CI provides it).