### PR TITLE
fix(#42): directory content-subspace prefix double-prepended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 ## [Unreleased]
 
 ### Fixed
+- [#42] `DirectoryLayer` no longer double-prepends the content subspace
+  key when constructing a returned `DirectorySubspace`. The prefix stored
+  in a directory node already includes the content subspace key
+  (`createInternal` composes `contentSubspace->key() . $allocatedPrefix`),
+  but `contentsOfNode()`, `createInternal()`, and `removeInternal()`
+  prepended it again. For the default (empty) content subspace this was
+  harmless; inside a partition it produced a doubled prefix
+  (P + P + key instead of P + key), landing directories at the wrong
+  location and breaking cross-binding interop. Unit tests in
+  `tests/Unit/DirectoryDoublePrefixTest.php` and functional tests in
+  `tests/Integration/DirectoryTest.php` cover both the empty and
+  non-empty content subspace cases.
 - [#73] Reverse range iteration (`getRange` / `getRangeAll` with `reverse: true`)
   now has regression coverage guaranteeing every key is yielded exactly once.
   No change to pagination behavior was required: the reverse branch already

--- a/src/Directory/DirectoryLayer.php
+++ b/src/Directory/DirectoryLayer.php
@@ -398,7 +398,7 @@ final readonly class DirectoryLayer
         }
 
         return new DirectorySubspace(
-            $this->contentSubspace->key() . $prefix,
+            $prefix,
             $path,
             $layer,
             $this,
@@ -479,7 +479,7 @@ final readonly class DirectoryLayer
         }
 
         return new DirectorySubspace(
-            $this->contentSubspace->key() . $prefix,
+            $prefix,
             $path,
             $layer,
             $this,
@@ -523,7 +523,7 @@ final readonly class DirectoryLayer
 
         $prefix = $this->getNodePrefix($node);
 
-        $tr->clearRangeStartsWith($this->contentSubspace->key() . $prefix);
+        $tr->clearRangeStartsWith($prefix);
         $tr->clearRangeStartsWith($node->key());
     }
 

--- a/tests/Integration/DirectoryTest.php
+++ b/tests/Integration/DirectoryTest.php
@@ -201,6 +201,96 @@ final class DirectoryTest extends TestCase
         $this->dir->move($this->getDatabase(), ['app', 'move_a'], ['app', 'move_b']);
     }
 
+    // --- issue #42: content subspace prefix must not be double-prepended ----
+
+    /**
+     * When a directory is created inside a partition, the stored prefix
+     * already includes the partition's content subspace key.  The returned
+     * DirectorySubspace must use that prefix directly — prepending the
+     * content subspace key a second time would produce a doubled prefix
+     * (P + P + key instead of P + key) and land data at the wrong location.
+     */
+    #[Test]
+    public function directoryInsidePartitionHasSingleContentPrefix(): void
+    {
+        $partition = $this->dir->create($this->getDatabase(), ['app', 'part42'], 'partition');
+        self::assertInstanceOf(DirectoryPartition::class, $partition);
+
+        $child = $partition->create($this->getDatabase(), ['child42']);
+        self::assertInstanceOf(DirectorySubspace::class, $child);
+
+        // The child's rawPrefix must contain the partition prefix exactly
+        // once — a double-prepend would produce partitionPrefix+partitionPrefix+...
+        $partitionPrefix = $partition->rawPrefix;
+        self::assertStringStartsWith($partitionPrefix === '' ? ' ' : $partitionPrefix, $child->rawPrefix);
+
+        $remainder = substr($child->rawPrefix, strlen($partitionPrefix));
+        self::assertNotEmpty($remainder, 'Child prefix must extend beyond partition prefix');
+        self::assertFalse(
+            str_starts_with($remainder, $partitionPrefix),
+            'Partition prefix appears twice in child rawPrefix (double-prepended)',
+        );
+    }
+
+    /**
+     * Round-trip: creating a directory inside a partition and then opening
+     * it must yield the same rawPrefix — the prefix must not change between
+     * create and open.
+     */
+    #[Test]
+    public function directoryInsidePartitionRoundTripsWithSamePrefix(): void
+    {
+        $partition = $this->dir->create($this->getDatabase(), ['app', 'part42rt'], 'partition');
+        self::assertInstanceOf(DirectoryPartition::class, $partition);
+
+        $created = $partition->create($this->getDatabase(), ['child_rt']);
+        $opened = $partition->open($this->getDatabase(), ['child_rt']);
+
+        self::assertSame($created->rawPrefix, $opened->rawPrefix);
+    }
+
+    /**
+     * Writing a key through a directory subspace inside a partition must
+     * land at exactly the expected key: the partition content prefix
+     * followed by the child directory's allocated suffix and the packed
+     * tuple — not at a doubled-prefix location.
+     */
+    #[Test]
+    public function writeThroughPartitionChildLandsAtSinglePrefixedKey(): void
+    {
+        $partition = $this->dir->create($this->getDatabase(), ['app', 'part42w'], 'partition');
+        self::assertInstanceOf(DirectoryPartition::class, $partition);
+
+        $child = $partition->create($this->getDatabase(), ['child_w']);
+        $child->pack(['mykey']);
+
+        // Write through the subspace
+        $this->getDatabase()->set($child->pack(['mykey']), 'myvalue');
+
+        // Read back directly using the raw key — must be found
+        $value = $this->getDatabase()->get($child->pack(['mykey']));
+        self::assertSame('myvalue', $value);
+
+        // The raw key must start with the child subspace's rawPrefix
+        // (which already includes the partition prefix exactly once)
+        $rawKey = $child->pack(['mykey']);
+        $childPrefix = $child->rawPrefix;
+        self::assertStringStartsWith($childPrefix === '' ? ' ' : $childPrefix, $rawKey);
+    }
+
+    /**
+     * A top-level directory (empty content subspace) must also have its
+     * stored prefix used directly, without re-prepending.
+     */
+    #[Test]
+    public function topLevelDirectoryPrefixIsNotDoublePrepended(): void
+    {
+        $created = $this->dir->create($this->getDatabase(), ['app', 'top42']);
+        $opened = $this->dir->open($this->getDatabase(), ['app', 'top42']);
+
+        self::assertSame($created->rawPrefix, $opened->rawPrefix);
+    }
+
     // --- issue #40: move() must bound path inputs and reject cycle/partition --
 
     /**

--- a/tests/Unit/DirectoryDoublePrefixTest.php
+++ b/tests/Unit/DirectoryDoublePrefixTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\FoundationDB\Tests\Unit;
+
+use CrazyGoat\FoundationDB\Directory\DirectoryLayer;
+use CrazyGoat\FoundationDB\Directory\DirectorySubspace;
+use CrazyGoat\FoundationDB\Subspace;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for the double-prepend bug from issue #42: the prefix stored
+ * in the directory node already includes the content subspace key, but
+ * `contentsOfNode()` and `createInternal()` prepended it again when
+ * constructing the returned `DirectorySubspace`.  Inside a partition
+ * (non-empty content subspace) this produced a doubled prefix (P + P + key
+ * instead of P + key), landing directories at the wrong location and
+ * breaking cross-binding interop.
+ *
+ * These tests exercise `contentsOfNode()` via reflection with a
+ * pre-built `Subspace` so no live `Transaction` is needed.  The
+ * `createInternal()` path (which requires a real transaction) is covered
+ * by the integration tests in `tests/Integration/DirectoryTest.php`.
+ */
+final class DirectoryDoublePrefixTest extends TestCase
+{
+    /**
+     * When the content subspace is empty (the default), the returned
+     * DirectorySubspace rawPrefix must equal the stored node prefix
+     * exactly — no content subspace key may be prepended again.
+     */
+    #[Test]
+    public function contentsOfNodeWithEmptyContentSubspaceDoesNotDoublePrepend(): void
+    {
+        $dir = new DirectoryLayer();
+        $nodePrefix = "\x01\x02\x03";
+        $node = $this->buildNode($dir, $nodePrefix);
+
+        $result = $this->invokeContentsOfNode($dir, $node, ['app', 'test'], '');
+
+        self::assertInstanceOf(DirectorySubspace::class, $result);
+        self::assertSame($nodePrefix, $result->rawPrefix);
+    }
+
+    /**
+     * When the content subspace is non-empty (as inside a partition),
+     * the stored prefix already starts with the content subspace key.
+     * The returned DirectorySubspace must use that stored prefix
+     * directly without prepending the content subspace key a second time.
+     */
+    #[Test]
+    public function contentsOfNodeWithNonEmptyContentSubspaceDoesNotDoublePrepend(): void
+    {
+        $contentSubspaceKey = "\xFEpartition";
+        $contentSubspace = new Subspace(rawPrefix: $contentSubspaceKey);
+        $nodeSubspace = new Subspace(rawPrefix: "\xFE");
+        $dir = new DirectoryLayer($nodeSubspace, $contentSubspace);
+
+        // The stored prefix already includes the content subspace key
+        // (createInternal composes it as contentSubspace->key() . allocatedPrefix).
+        $rawAllocated = "\x01\xAA\xBB";
+        $storedPrefix = $contentSubspaceKey . $rawAllocated;
+        $node = $this->buildNode($dir, $storedPrefix);
+
+        $result = $this->invokeContentsOfNode($dir, $node, ['app', 'inner'], '');
+
+        self::assertInstanceOf(DirectorySubspace::class, $result);
+        self::assertSame($storedPrefix, $result->rawPrefix);
+    }
+
+    /**
+     * The partition branch of contentsOfNode() already passed $prefix
+     * directly; verify it stays consistent with the non-partition branch.
+     */
+    #[Test]
+    public function contentsOfNodePartitionBranchUsesPrefixDirectly(): void
+    {
+        $contentSubspaceKey = "\xFEpartition";
+        $contentSubspace = new Subspace(rawPrefix: $contentSubspaceKey);
+        $nodeSubspace = new Subspace(rawPrefix: "\xFE");
+        $dir = new DirectoryLayer($nodeSubspace, $contentSubspace);
+
+        $rawAllocated = "\x01\xCC\xDD";
+        $storedPrefix = $contentSubspaceKey . $rawAllocated;
+        $node = $this->buildNode($dir, $storedPrefix);
+
+        $result = $this->invokeContentsOfNode($dir, $node, ['app', 'part'], 'partition');
+
+        // DirectoryPartition blocks key() but rawPrefix is accessible
+        self::assertSame($storedPrefix, $result->rawPrefix);
+    }
+
+    /**
+     * Build a Subspace that looks like a node in the given DirectoryLayer's
+     * nodeSubspace, containing the given prefix.  The node key is:
+     * nodeSubspace->key() . Tuple::pack([$prefix]).
+     */
+    private function buildNode(DirectoryLayer $dir, string $prefix): Subspace
+    {
+        $ref = new \ReflectionProperty(DirectoryLayer::class, 'nodeSubspace');
+        /** @var Subspace $nodeSubspace */
+        $nodeSubspace = $ref->getValue($dir);
+
+        return $nodeSubspace->subspace($prefix);
+    }
+
+    /**
+     * @param list<string> $path
+     */
+    private function invokeContentsOfNode(
+        DirectoryLayer $dir,
+        Subspace $node,
+        array $path,
+        string $layer,
+    ): DirectorySubspace {
+        $method = new ReflectionMethod(DirectoryLayer::class, 'contentsOfNode');
+
+        /** @var DirectorySubspace */
+        return $method->invoke($dir, $node, $path, $layer);
+    }
+}


### PR DESCRIPTION
Closes #42

## Summary

The prefix stored in a directory node already includes the content subspace key, but `contentsOfNode()`, `createInternal()`, and `removeInternal()` prepended it again when constructing the returned `DirectorySubspace` or clearing content keys.

For the default (empty) content subspace this was harmless. Inside a partition (non-empty content subspace) it produced a doubled prefix (P + P + key instead of P + key), landing directories at the wrong location and breaking cross-binding interop.

## Changes

- **`src/Directory/DirectoryLayer.php`**: Removed the redundant `contentSubspace->key()` prepend in `contentsOfNode()`, `createInternal()`, and `removeInternal()` — the stored prefix is now used directly, matching the existing partition branch behavior.

## Tests

- **Unit tests** (`tests/Unit/DirectoryDoublePrefixTest.php`): 3 tests covering `contentsOfNode()` with empty content subspace, non-empty content subspace, and partition layer
- **Integration tests** (`tests/Integration/DirectoryTest.php`): 4 tests covering directory creation inside a partition (single prefix, round-trip, key write/read, and top-level directory prefix)
- All 644 tests pass (436 unit + 208 integration)
- Lint clean (PHPCS + Rector dry-run + PHPStan level 9)