### PR TITLE
fix(#38): break Transaction<->Snapshot reference cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 ## [Unreleased]
 
 ### Fixed
+- [#38] `Transaction::snapshot()` no longer caches the `Snapshot` on the
+  parent transaction. The cached instance closed a reference cycle
+  (`Transaction -> snapshotInstance -> Snapshot -> parentTransaction`) that
+  kept both objects alive by refcount, deferring
+  `fdb_transaction_destroy()` to the cycle collector — or to process
+  shutdown when `zend.enable_gc=0`. A long-running worker calling
+  `readTransact()`, directory operations (`HighContentionAllocator`), or
+  `Locality` therefore accumulated undestroyed native FDB transaction
+  handles. `snapshot()` now returns a fresh `Snapshot` per call; the
+  `Snapshot` still anchors its parent one-directionally, so the shared
+  native handle remains valid for the snapshot's lifetime and both are
+  freed deterministically on scope exit. Lifetime semantics are documented
+  in `docs/transactions.md`; unit coverage lives in
+  `tests/Unit/SnapshotLifetimeTest.php` and functional coverage in
+  `tests/Integration/TransactionLifecycleTest.php`.
 - [#73] Reverse range iteration (`getRange` / `getRangeAll` with `reverse: true`)
   now has regression coverage guaranteeing every key is yielded exactly once.
   No change to pagination behavior was required: the reverse branch already

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -198,6 +198,16 @@ $db->transact(function (Transaction $tr) {
 - Useful for frequently-read data that changes often but doesn't need strict consistency
 - You can mix snapshot and regular reads in the same transaction
 
+### Lifetime and ownership
+
+- Each call to `$tr->snapshot()` returns a **new** `Snapshot` instance; don't rely on
+  identity (`===`) between two calls.
+- A `Snapshot` shares its parent transaction's native handle. It holds a strong
+  reference to the parent `Transaction`, so the native handle stays valid for as long
+  as the `Snapshot` exists.
+- Once both the `Transaction` and its `Snapshot` go out of scope, the native transaction
+  is destroyed immediately by refcounting — no garbage-collection cycle is involved.
+
 ---
 
 ## Read-Only Transactions

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -15,8 +15,6 @@ use FFI\CData;
 
 final class Transaction extends ReadTransaction implements Transactor
 {
-    private ?Snapshot $snapshotInstance = null;
-
     public function __construct(
         CData $tpointer,
         Database $db,
@@ -315,7 +313,13 @@ final class Transaction extends ReadTransaction implements Transactor
 
     public function snapshot(): Snapshot
     {
-        return $this->snapshotInstance ??= new Snapshot($this->tpointer, $this->db, $this->client, $this);
+        // A fresh Snapshot is returned on every call. Snapshot holds a strong
+        // reference back to this Transaction to keep the shared native handle
+        // alive; caching it here as well would create a reference cycle
+        // (Transaction -> Snapshot -> Transaction) that defers
+        // fdb_transaction_destroy() to the cycle collector — or to process
+        // shutdown when zend.enable_gc is disabled (#38).
+        return new Snapshot($this->tpointer, $this->db, $this->client, $this);
     }
 
     public function transact(callable $fn): mixed

--- a/tests/Integration/TransactionLifecycleTest.php
+++ b/tests/Integration/TransactionLifecycleTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\FoundationDB\Tests\Integration;
+
+use CrazyGoat\FoundationDB\Directory\DirectoryLayer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Functional tests for native transaction handle lifetime (#38).
+ *
+ * Transaction::snapshot() used to cache the Snapshot on the Transaction,
+ * closing a reference cycle (Transaction -> Snapshot -> Transaction) that
+ * deferred fdb_transaction_destroy() to the cycle collector. A long-running
+ * worker therefore accumulated undestroyed native transaction handles —
+ * instantly visible as cyclic garbage that only gc_collect_cycles() could
+ * reclaim.
+ *
+ * These tests assert the handles are released deterministically: weak
+ * references die without running the collector, and directory creation
+ * (which allocates through HighContentionAllocator, a heavy snapshot()
+ * user) leaves no cyclic garbage behind.
+ */
+final class TransactionLifecycleTest extends TestCase
+{
+    use DatabaseCleanupTrait;
+
+    #[Test]
+    public function transactionsWithSnapshotsAreDestroyedWithoutCycleCollector(): void
+    {
+        $db = $this->getDatabase();
+
+        // Remove any pre-existing cyclic garbage so the assertions below
+        // measure only what this loop leaves behind.
+        gc_collect_cycles();
+
+        $weakTransactions = [];
+
+        for ($i = 0; $i < 100; $i++) {
+            $transaction = $db->createTransaction();
+            $snapshot = $transaction->snapshot();
+
+            // Exercise a real read through the snapshot handle.
+            $snapshot->getReadVersion()->await();
+
+            $weakTransactions[] = \WeakReference::create($transaction);
+            unset($transaction, $snapshot);
+        }
+
+        foreach ($weakTransactions as $i => $weakTransaction) {
+            self::assertNull(
+                $weakTransaction->get(),
+                sprintf(
+                    'Transaction #%d was not destroyed deterministically — reference cycle is present',
+                    $i,
+                ),
+            );
+        }
+    }
+
+    #[Test]
+    public function directoryCreationDoesNotLeaveCyclicGarbage(): void
+    {
+        $db = $this->getDatabase();
+        $directoryLayer = new DirectoryLayer();
+        $root = 'lifecycle-' . bin2hex(random_bytes(4));
+
+        try {
+            gc_collect_cycles();
+
+            for ($i = 0; $i < 30; $i++) {
+                $directoryLayer->createOrOpen($db, [$root, 'dir' . $i]);
+            }
+
+            self::assertSame(
+                0,
+                gc_collect_cycles(),
+                'Directory creation leaked cyclic Transaction/Snapshot pairs',
+            );
+        } finally {
+            $directoryLayer->removeIfExists($db, [$root]);
+        }
+    }
+}

--- a/tests/Unit/SnapshotLifetimeTest.php
+++ b/tests/Unit/SnapshotLifetimeTest.php
@@ -6,6 +6,7 @@ namespace CrazyGoat\FoundationDB\Tests\Unit;
 
 use CrazyGoat\FoundationDB\Database;
 use CrazyGoat\FoundationDB\NativeClient;
+use CrazyGoat\FoundationDB\ReadTransaction;
 use CrazyGoat\FoundationDB\Transaction;
 use FFI;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
@@ -142,7 +143,11 @@ final class SnapshotLifetimeTest extends TestCase
 
     private function setProperty(object $object, string $name, mixed $value): void
     {
-        $property = new \ReflectionProperty($object, $name);
+        // Resolve the property against its declaring class: readonly
+        // properties may only be reflection-initialized from that scope,
+        // and on PHP < 8.4 a subclass scope (e.g. Transaction for props
+        // declared on ReadTransaction) is rejected.
+        $property = new \ReflectionProperty(ReadTransaction::class, $name);
         $property->setValue($object, $value);
     }
 

--- a/tests/Unit/SnapshotLifetimeTest.php
+++ b/tests/Unit/SnapshotLifetimeTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\FoundationDB\Tests\Unit;
+
+use CrazyGoat\FoundationDB\Database;
+use CrazyGoat\FoundationDB\NativeClient;
+use CrazyGoat\FoundationDB\Transaction;
+use FFI;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the Transaction <-> Snapshot lifetime contract (#38).
+ *
+ * Transaction::snapshot() must return a fresh Snapshot on every call. The
+ * Snapshot holds a strong reference back to its parent Transaction to keep
+ * the shared native handle alive; caching the Snapshot on the Transaction
+ * used to close a reference cycle (Transaction -> Snapshot -> Transaction)
+ * that deferred fdb_transaction_destroy() to the cycle collector — or to
+ * process shutdown when zend.enable_gc is disabled.
+ *
+ * These tests run without the native client library: the objects under test
+ * are built via reflection (newInstanceWithoutConstructor) with a fake
+ * transaction pointer from a types-only FFI scope. When the parent
+ * Transaction is finally freed, its destructor touches the uninitialized
+ * NativeClient::$fdb property; the resulting \Error is expected and is used
+ * as the observable proof that the destructor ran.
+ */
+#[RequiresPhpExtension('ffi')]
+final class SnapshotLifetimeTest extends TestCase
+{
+    private ?FFI $scope = null;
+
+    // -- snapshot() identity ----------------------------------------------------
+
+    #[Test]
+    public function snapshotReturnsFreshInstancePerCall(): void
+    {
+        $transaction = $this->createTransaction();
+        $first = $transaction->snapshot();
+        $second = $transaction->snapshot();
+
+        self::assertNotSame(
+            $first,
+            $second,
+            'snapshot() must not cache the Snapshot on the Transaction — caching closes a reference cycle',
+        );
+
+        $this->release($first, $second, $transaction);
+    }
+
+    // -- lifetime / cycle -------------------------------------------------------
+
+    #[Test]
+    public function snapshotAnchorsParentTransactionUntilReleased(): void
+    {
+        $transaction = $this->createTransaction();
+        $weakTransaction = \WeakReference::create($transaction);
+        $snapshot = $transaction->snapshot();
+
+        // Dropping the transaction variable must NOT free it while the
+        // snapshot holds its anchor reference.
+        $this->release($transaction);
+
+        self::assertNotNull(
+            $weakTransaction->get(),
+            'Snapshot must keep the parent Transaction (and its native handle) alive',
+        );
+
+        // Releasing the snapshot drops the last reference; the parent must be
+        // freed deterministically WITHOUT running the cycle collector.
+        $destructorRan = $this->release($snapshot);
+
+        self::assertTrue($destructorRan, 'Expected Transaction::__destruct() to run on release');
+        self::assertNull(
+            $weakTransaction->get(),
+            'Transaction must be freed by refcounting alone, without gc_collect_cycles()',
+        );
+    }
+
+    #[Test]
+    public function droppingTransactionAndSnapshotDoesNotRequireCycleCollector(): void
+    {
+        $transaction = $this->createTransaction();
+        $weakTransaction = \WeakReference::create($transaction);
+        $snapshot = $transaction->snapshot();
+        $weakSnapshot = \WeakReference::create($snapshot);
+
+        $destructorRan = $this->release($transaction, $snapshot);
+
+        self::assertTrue($destructorRan, 'Expected Transaction::__destruct() to run on release');
+        self::assertNull($weakTransaction->get(), 'Transaction leaked — reference cycle is back');
+        self::assertNull($weakSnapshot->get(), 'Snapshot leaked — reference cycle is back');
+    }
+
+    // -- helpers ----------------------------------------------------------------
+
+    /**
+     * Build a Transaction without invoking its constructor (no native calls).
+     */
+    private function createTransaction(): Transaction
+    {
+        $reflection = new \ReflectionClass(Transaction::class);
+        /** @var Transaction $transaction */
+        $transaction = $reflection->newInstanceWithoutConstructor();
+
+        $this->setProperty($transaction, 'tpointer', $this->scope()->new('FDBTransaction*'));
+        $this->setProperty($transaction, 'db', $this->bareInstance(Database::class));
+        $this->setProperty($transaction, 'client', $this->bareInstance(NativeClient::class));
+        $this->setProperty($transaction, 'isSnapshot', false);
+
+        return $transaction;
+    }
+
+    /**
+     * Types-only FFI scope: opaque struct pointer without any native library.
+     */
+    private function scope(): FFI
+    {
+        return $this->scope ??= FFI::cdef(
+            'typedef struct FDB_transaction FDBTransaction;',
+        );
+    }
+
+    /**
+     * Instance without constructor for collaborators whose state is unused.
+     *
+     * @template T of object
+     *
+     * @param class-string<T> $class
+     *
+     * @return T
+     */
+    private function bareInstance(string $class): object
+    {
+        /** @var T */
+        return (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+    }
+
+    private function setProperty(object $object, string $name, mixed $value): void
+    {
+        $property = new \ReflectionProperty($object, $name);
+        $property->setValue($object, $value);
+    }
+
+    /**
+     * Drop strong references and report whether a destructor threw.
+     *
+     * Releasing the last reference to the parent Transaction runs
+     * Transaction::__destruct(), which dereferences the uninitialized fake
+     * NativeClient::$fdb and throws \Error. That throw is the observable
+     * "destructor ran" signal; it is caught here so tests stay clean.
+     *
+     * Writing through the by-ref variadic slots is invisible to PHPStan's
+     * by-ref analysis, hence the targeted ignores.
+     *
+     * @param ?object ...$references Variables to release (by reference)
+     */
+    // @phpstan-ignore-next-line parameterByRef.unusedType, parameterByRef.unusedType
+    private function release(?object &...$references): bool
+    {
+        $destructorRan = false;
+
+        try {
+            // Iterate keys only: a foreach value copy would keep the last
+            // object alive until after this function returns, moving the
+            // destructor throw outside the try block.
+            foreach (array_keys($references) as $key) {
+                $references[$key] = null; // @phpstan-ignore parameterByRef.type
+            }
+        } catch (\Error) {
+            $destructorRan = true;
+        }
+
+        return $destructorRan;
+    }
+}


### PR DESCRIPTION
Closes #38

## Problem

`Transaction::snapshot()` cached the `Snapshot` instance on the parent transaction:

- `Transaction -> $snapshotInstance -> Snapshot -> $parentTransaction -> Transaction`

Both sides held strong references, so refcounts never reached zero on scope exit and
`Transaction::__destruct()` (i.e. `fdb_transaction_destroy()`) only ran via the cycle
collector — or at process shutdown when `zend.enable_gc=0`. The cycle was created on
every `snapshot()` call: `Database::readTransact()`, every `HighContentionAllocator::allocate()`
(i.e. every directory create/open), and `Locality`. A long-running worker therefore
accumulated undestroyed native FDB transaction handles.

## Change

`snapshot()` now returns a **fresh** `Snapshot` per call (as proposed in the issue).
The `Snapshot` still anchors its parent one-directionally, so the shared native handle
remains valid for the snapshot's lifetime; once both go out of scope, destruction is
deterministic by refcounting alone. Read-only semantics are unchanged.

## Verification

| Check | Result |
|---|---|
| `composer lint` (PHPCS + Rector + PHPStan L9) | ✅ no errors |
| `composer test:unit` | ✅ 436 tests |
| Integration suite (Docker 5-node cluster) | ✅ 206 tests |
| New unit tests vs old code | ❌ fail as expected (cycle present) |
| New integration tests vs old code | ❌ fail as expected (90 cyclic objects collected after 30 directory creates) |

New tests:
- `tests/Unit/SnapshotLifetimeTest.php` — native-free (reflection-built objects, types-only FFI scope): fresh instance per call, snapshot anchors parent, deterministic destruction without `gc_collect_cycles()`, destructor-run observable.
- `tests/Integration/TransactionLifecycleTest.php` — weak-ref loop over `createTransaction()+snapshot()+getReadVersion()`; directory creation loop leaves zero cyclic garbage.

Docs: lifetime/ownership notes added to `docs/transactions.md`. Changelog entry added under `[Unreleased] → Fixed`.