### PR TITLE
fix(#80): remove stale unit test counts from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ composer rector        # Rector dry-run
 ### Testing
 
 ```bash
-composer test:unit     # 317 unit tests (no FDB required)
+composer test:unit     # Unit tests (no FDB required)
 ```
 
 Integration tests require a running FoundationDB instance:

--- a/workflow.md
+++ b/workflow.md
@@ -85,7 +85,7 @@ composer test   # All tests pass (unit + integration where applicable)
 
 ```bash
 composer test                # All tests
-composer test:unit           # Unit tests only (317 tests, no FDB required)
+composer test:unit           # Unit tests only (no FDB required)
 composer test:integration    # Integration tests (requires running FDB cluster)
 ```
 


### PR DESCRIPTION
Closes #80

Dropped hardcoded unit-test counts that had drifted 45% (docs said 317, actual 461). Kept the durable part: `no FDB required`. Docs-only change — no code, tests, or changelog impact.