### PR TITLE
test(#45): strengthen partition subdirectory test to assert prefix layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,16 @@
   so legitimate deeply-nested user data is unaffected.
 
 ### Added
+- [#45] `tests/Integration/DirectoryTest::directoryPartitionSubdirectories`
+  previously only asserted that a child directory created inside a partition
+  had the right path and *existed* — it never wrote or read an actual key
+  through the returned subspace, so a non-interoperable partition prefix
+  layout could pass CI. The test now asserts the child subspace's prefix
+  lives strictly inside the partition's prefix space, round-trips a write
+  through `$sub->pack(['k'])` and reads it back via a raw
+  `getRangeAllStartsWith($partition->rawPrefix)` scan, proving partition-born
+  content keys land inside (not outside or colliding with) the partition
+  boundary.
 - [#71] `Database::getClientStatus()` now accepts an optional `bool $asArray = false`
   parameter. When `true`, it returns the decoded status as an
   `array<string, mixed>`, making its return type consistent with

--- a/docs/directory-layer.md
+++ b/docs/directory-layer.md
@@ -168,6 +168,16 @@ $partition = $dir->create($db, ['isolated'], layer: 'partition');
 $sub = $partition->createOrOpen($db, ['data']);
 ```
 
+A partition's subdirectories carry the partition's own prefix (the internal
+layer is built on `rawPrefix` and `rawPrefix . "\xFE"`), so content keys of a
+partition-born child always *start with* the partition's `rawPrefix` and
+strictly extend it. The integration suite asserts this exact byte layout
+(`tests/Integration/DirectoryTest.php::directoryPartitionSubdirectories`):
+it round-trips a write through the returned child subspace and verifies a raw
+`getRangeAllStartsWith($partition->rawPrefix)` scan surfaces that key — writing
+a test that only asserts `exists()` would not catch a partition prefix that
+silently leaked bytes outside the partition boundary.
+
 ## Custom Node/Content Subspaces
 
 ```php

--- a/tests/Integration/DirectoryTest.php
+++ b/tests/Integration/DirectoryTest.php
@@ -8,6 +8,7 @@ use CrazyGoat\FoundationDB\Directory\DirectoryException;
 use CrazyGoat\FoundationDB\Directory\DirectoryLayer;
 use CrazyGoat\FoundationDB\Directory\DirectoryPartition;
 use CrazyGoat\FoundationDB\Directory\DirectorySubspace;
+use CrazyGoat\FoundationDB\KeyValue;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -609,6 +610,34 @@ final class DirectoryTest extends TestCase
         self::assertSame(['child'], $sub->getPath());
 
         self::assertTrue($partition->exists($this->getDatabase(), ['child']));
+
+        // The child's content keys must live *inside* the partition's
+        // prefix space — otherwise a partition-born directory leaks bytes
+        // outside its boundary and collides with sibling partitions or the
+        // top-level content subspace. The child subspace is built on the
+        // partition's own internal layer, so its prefix is partitionPrefix
+        // followed by the allocated sub-prefix (+ a trailing tuple EOC byte
+        // when we pack a key). Asserting the exact relationship below is
+        // what actually validates the partition prefix layout end to end.
+        self::assertTrue(str_starts_with($sub->rawPrefix, $partition->rawPrefix));
+        self::assertNotSame($sub->rawPrefix, $partition->rawPrefix);
+
+        // Round-trip a write through the returned subspace and verify the
+        // stored key really begins with the child subspace prefix (and thus
+        // lives under the partition boundary).
+        $db = $this->getDatabase();
+        $db->set($sub->pack(['k']), 'v');
+
+        $key = $sub->pack(['k']);
+        self::assertTrue(str_starts_with($key, $partition->rawPrefix));
+        self::assertSame('v', $db->get($key));
+
+        // A raw range scan over the *partition* prefix must surface exactly
+        // the key we wrote through the child subspace — proving the write
+        // landed inside the partition, not merely in the global content space.
+        $kvs = $db->getRangeAllStartsWith($partition->rawPrefix);
+        $keys = array_map(static fn (KeyValue $kv): string => $kv->key, $kvs);
+        self::assertContains($key, $keys);
     }
 
     #[Test]


### PR DESCRIPTION
Closes #45

The partition subdirectory test only asserted that a child created inside a partition had the right path and existed — nothing wrote or read an actual key through the returned subspace, so a partition prefix that silently leaked bytes outside the partition boundary would pass CI.

Now the test:
- asserts the child subspace `rawPrefix` strictly begins with the partition `rawPrefix`,
- round-trips a write through `$sub->pack(['k'])` and reads it back,
- verifies a raw `getRangeAllStartsWith($partition->rawPrefix)` scan surfaces that exact key.

(The other point raised in #45 — `getAddressesForKey` asserting only `assertNotEmpty` — was already strengthened in PR #36, so that half is already covered.)

## Verification
- `composer lint` (PHPCS + Rector + PHPStan level 9): no errors
- `composer test:unit`: 469 tests OK
- `--testsuite=Integration` against live FDB in Docker: 209 tests OK (strengthened partition test: 9 assertions OK)
