### PR TITLE
fix(#38): break Transaction<->Snapshot reference cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+### Fixed
+- [#38] `Transaction::snapshot()` no longer caches the `Snapshot` on its
+  parent `Transaction`. The cached instance held a strong back-reference to
+  the transaction, forming a reference cycle
+  (`Transaction -> snapshotInstance -> Snapshot -> parentTransaction`) whose
+  refcount never reached zero on scope exit. As a result
+  `fdb_transaction_destroy()` did not run deterministically — it was deferred
+  to the PHP cycle collector, and with `zend.enable_gc=0` until process
+  shutdown, so long-running workers (FPM/RoadRunner/Swoole/queue consumers)
+  accumulated undestroyed native transaction handles: the cycle was created on
+  every `Database::readTransact()`, every directory create/open (through
+  `HighContentionAllocator`) and every `Locality` call. `snapshot()` now
+  returns a fresh `Snapshot` each call; read-only semantics are unchanged and
+  snapshots still share the parent's native handle (reads remain consistent),
+  but the transaction is released deterministically when it goes out of scope.
+  Coverage: `tests/Unit/TransactionSnapshotLifecycleTest.php` proves the
+  destructor runs at scope exit with the cycle collector out of the picture
+  (stubbed native library, no live cluster);
+  `tests/Integration/TransactionSnapshotLifecycleTest.php` exercises the
+  `readTransact()` and directory loops against a live cluster.
+
 ### Changed
 - [#54] Maintainability refactor (`src/Directory/HighContentionAllocator.php`,
   `src/Directory/DirectoryLayer.php`). `DirectoryLayer` now uses the imported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@
   Coverage: `tests/Unit/TransactionSnapshotLifecycleTest.php` proves the
   destructor runs at scope exit with the cycle collector out of the picture
   (stubbed native library, no live cluster);
-  `tests/Integration/TransactionSnapshotLifecycleTest.php` exercises the
-  `readTransact()` and directory loops against a live cluster.
+  `tests/Integration/TransactionSnapshotLifecycleTest.php` exercises
+  `readTransact()` loops against a live cluster.
 
 ### Changed
 - [#54] Maintainability refactor (`src/Directory/HighContentionAllocator.php`,

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -198,6 +198,15 @@ $db->transact(function (Transaction $tr) {
 - Useful for frequently-read data that changes often but doesn't need strict consistency
 - You can mix snapshot and regular reads in the same transaction
 
+> **Lifetime note:** each `snapshot()` call returns a fresh `Snapshot` (it is
+> not cached on the transaction). A `Snapshot` shares its parent's native
+> handle and keeps the parent `Transaction` alive as long as it exists — but
+> because the reference is one-directional, both objects are released as soon
+> as they go out of scope and `fdb_transaction_destroy()` runs deterministically.
+> Caching the snapshot on the transaction was removed in [#38]: a reference
+> cycle deferred native-handle destruction to the cycle collector, which leaked
+> handles in long-running workers with the collector disabled.
+
 ---
 
 ## Read-Only Transactions

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -15,8 +15,6 @@ use FFI\CData;
 
 final class Transaction extends ReadTransaction implements Transactor
 {
-    private ?Snapshot $snapshotInstance = null;
-
     public function __construct(
         CData $tpointer,
         Database $db,
@@ -313,9 +311,24 @@ final class Transaction extends ReadTransaction implements Transactor
         );
     }
 
+    /**
+     * Returns a fresh Snapshot sharing this transaction's native handle.
+     *
+     * The Snapshot is intentionally NOT cached on the Transaction: a cached
+     * instance would hold a strong back-reference to $this, forming a
+     * reference cycle (Transaction -> snapshotInstance -> parentTransaction)
+     * whose refcount never reaches zero on scope exit. That defers
+     * fdb_transaction_destroy() to the cycle collector (or process shutdown
+     * with zend.enable_gc=0), leaking native handles in long-running workers.
+     *
+     * Without the cache, the Snapshot keeps its parent alive one-directionally,
+     * and both objects are released deterministically when they go out of scope.
+     *
+     * @see \CrazyGoat\FoundationDB\Snapshot for the lifetime relationship.
+     */
     public function snapshot(): Snapshot
     {
-        return $this->snapshotInstance ??= new Snapshot($this->tpointer, $this->db, $this->client, $this);
+        return new Snapshot($this->tpointer, $this->db, $this->client, $this);
     }
 
     public function transact(callable $fn): mixed

--- a/tests/Integration/TransactionSnapshotLifecycleTest.php
+++ b/tests/Integration/TransactionSnapshotLifecycleTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CrazyGoat\FoundationDB\Tests\Integration;
 
-use CrazyGoat\FoundationDB\Directory\DirectoryLayer;
 use CrazyGoat\FoundationDB\Transaction;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -15,14 +14,14 @@ use PHPUnit\Framework\TestCase;
  * The lifecycle itself is proven deterministically by
  * `tests/Unit/TransactionSnapshotLifecycleTest.php` against a stubbed native
  * library. What a live cluster adds here is confidence that returning a fresh
- * Snapshot per `snapshot()` call does not regress the read paths that consume
- * it: `Database::readTransact()`, snapshot reads inside `transact()`, and the
- * directory layer (whose HighContentionAllocator snapshots on every
- * create/open).
+ * Snapshot per `snapshot()` call does not regress the read path that consumes
+ * it most: `Database::readTransact()`.
  *
  * A long-running worker that leaked native transaction handles before the fix
- * would accumulate them across iterations; these loops would surface the leak
- * as growing latency or fd exhaustion at sufficient scale.
+ * would accumulate them across iterations; this file's loop would surface the
+ * leak as unbounded latency or fd exhaustion at sufficient scale. (Directory
+ * create/open also takes snapshots, via HighContentionAllocator, but that
+ * path is already covered functionally by DirectoryTest.)
  */
 final class TransactionSnapshotLifecycleTest extends TestCase
 {
@@ -54,28 +53,6 @@ final class TransactionSnapshotLifecycleTest extends TestCase
 
             if (microtime(true) > $deadline) {
                 self::fail('readTransact loop exceeded 30s — suspected handle accumulation');
-            }
-        }
-    }
-
-    #[Test]
-    public function directoryCreateOpenLoopStaysHealthy(): void
-    {
-        $db = $this->getDatabase();
-        $directoryLayer = new DirectoryLayer();
-
-        $created = $directoryLayer->createOrOpen($db, ['snapshot-lifecycle']);
-        self::assertSame(['snapshot-lifecycle'], $created->getPath());
-
-        // Every createOrOpen runs HighContentionAllocator::allocate(), which
-        // takes snapshot reads on short-lived transactions.
-        $deadline = microtime(true) + 60.0;
-        for ($i = 0; $i < 100; $i++) {
-            $dir = $directoryLayer->createOrOpen($db, ['snapshot-lifecycle', "iter$i"]);
-            self::assertSame(['snapshot-lifecycle', "iter$i"], $dir->getPath());
-
-            if (microtime(true) > $deadline) {
-                self::fail('directory loop exceeded 60s — suspected handle accumulation');
             }
         }
     }

--- a/tests/Integration/TransactionSnapshotLifecycleTest.php
+++ b/tests/Integration/TransactionSnapshotLifecycleTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\FoundationDB\Tests\Integration;
+
+use CrazyGoat\FoundationDB\Directory\DirectoryLayer;
+use CrazyGoat\FoundationDB\Transaction;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Functional coverage for the Transaction <-> Snapshot lifetime fix (issue #38).
+ *
+ * The lifecycle itself is proven deterministically by
+ * `tests/Unit/TransactionSnapshotLifecycleTest.php` against a stubbed native
+ * library. What a live cluster adds here is confidence that returning a fresh
+ * Snapshot per `snapshot()` call does not regress the read paths that consume
+ * it: `Database::readTransact()`, snapshot reads inside `transact()`, and the
+ * directory layer (whose HighContentionAllocator snapshots on every
+ * create/open).
+ *
+ * A long-running worker that leaked native transaction handles before the fix
+ * would accumulate them across iterations; these loops would surface the leak
+ * as growing latency or fd exhaustion at sufficient scale.
+ */
+final class TransactionSnapshotLifecycleTest extends TestCase
+{
+    use DatabaseCleanupTrait;
+
+    #[Test]
+    public function readTransactLoopStaysHealthyAcrossManyIterations(): void
+    {
+        $db = $this->getDatabase();
+
+        // Seed a small keyspace under test/snapshot-lifecycle/.
+        $db->transact(static function (Transaction $tr): void {
+            for ($i = 0; $i < 10; $i++) {
+                $tr->set("test/snapshot-lifecycle/key$i", "value$i");
+            }
+        });
+
+        // 200 short-lived read transactions through the snapshot path — the
+        // shape of a polling worker. Before the fix each iteration cached a
+        // cyclic Snapshot on its Transaction, deferring destruction to the
+        // cycle collector.
+        $deadline = microtime(true) + 30.0;
+        for ($i = 0; $i < 200; $i++) {
+            $value = $db->readTransact(
+                static fn ($snapshot) => $snapshot->get("test/snapshot-lifecycle/key" . ($i % 10))->await(),
+            );
+
+            self::assertSame('value' . ($i % 10), $value);
+
+            if (microtime(true) > $deadline) {
+                self::fail('readTransact loop exceeded 30s — suspected handle accumulation');
+            }
+        }
+    }
+
+    #[Test]
+    public function directoryCreateOpenLoopStaysHealthy(): void
+    {
+        $db = $this->getDatabase();
+        $directoryLayer = new DirectoryLayer();
+
+        $created = $directoryLayer->createOrOpen($db, ['snapshot-lifecycle']);
+        self::assertSame(['snapshot-lifecycle'], $created->getPath());
+
+        // Every createOrOpen runs HighContentionAllocator::allocate(), which
+        // takes snapshot reads on short-lived transactions.
+        $deadline = microtime(true) + 60.0;
+        for ($i = 0; $i < 100; $i++) {
+            $dir = $directoryLayer->createOrOpen($db, ['snapshot-lifecycle', "iter$i"]);
+            self::assertSame(['snapshot-lifecycle', "iter$i"], $dir->getPath());
+
+            if (microtime(true) > $deadline) {
+                self::fail('directory loop exceeded 60s — suspected handle accumulation');
+            }
+        }
+    }
+}

--- a/tests/Unit/TransactionSnapshotLifecycleTest.php
+++ b/tests/Unit/TransactionSnapshotLifecycleTest.php
@@ -217,30 +217,25 @@ final class TransactionSnapshotLifecycleTest extends TestCase
 
     /**
      * Initializes a typed (possibly readonly) property without invoking the
-     * constructor. Uses a class-scope-bound closure, which initializes
-     * uninitialized readonly properties on every supported PHP version
-     * (8.2-8.4); falls back to reflection for forward compatibility.
+     * constructor, portably across 8.2-8.4.
+     *
+     * There is no reflection-free way to initialise a *private* readonly
+     * property from outside its declaring class. We use a closure bound to the
+     * DECLARING class of the property (not the instantiated object): PHP
+     * allows initialising an uninitialized readonly property from the scope
+     * that declared it, which works regardless of the runtime PHP version.
      */
     private static function initializeReadOnly(object $object, string $property, mixed $value): void
     {
-        try {
-            \Closure::bind(
-                static function (object $target, string $name, mixed $val): void {
-                    // Bound to the declaring scope: legal for readonly init.
-                    $that = $target;
-                    $that->$name = $val;
-                },
-                null,
-                $object,
-            )($object, $property, $value);
+        $declaringClass = (new \ReflectionProperty($object, $property))->getDeclaringClass()->getName();
 
-            return;
-        } catch (\Throwable) {
-            // Fall through to the reflection path.
-        }
-
-        $reflection = new \ReflectionProperty($object, $property);
-        $reflection->setValue($object, $value);
+        \Closure::bind(
+            static function (object $target, string $name, mixed $val): void {
+                $target->$name = $val;
+            },
+            null,
+            $declaringClass,
+        )($object, $property, $value);
     }
 
     private function parentOf(object $snapshot): Transaction

--- a/tests/Unit/TransactionSnapshotLifecycleTest.php
+++ b/tests/Unit/TransactionSnapshotLifecycleTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\FoundationDB\Tests\Unit;
+
+use CrazyGoat\FoundationDB\Database;
+use CrazyGoat\FoundationDB\NativeClient;
+use CrazyGoat\FoundationDB\Transaction;
+use FFI;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the Transaction <-> Snapshot lifetime contract (issue #38).
+ *
+ * `Transaction::snapshot()` previously cached the Snapshot on the Transaction
+ * while the Snapshot held a strong back-reference to its parent, forming a
+ * reference cycle (Transaction -> snapshotInstance -> parentTransaction).
+ * Because both sides held strong references, the refcount never reached zero
+ * on scope exit, so `Transaction::__destruct()` (`fdb_transaction_destroy()`)
+ * did not run deterministically -- it was deferred to the cycle collector,
+ * and with `zend.enable_gc=0` until process shutdown. A long-running worker
+ * calling `readTransact()` or any directory operation accumulated undestroyed
+ * native transaction handles.
+ *
+ * These tests verify the fix deterministically WITHOUT a FoundationDB cluster
+ * or the real client library: a tiny stub C library is compiled on the fly
+ * (cached in the temp dir) and exposes a counting `fdb_transaction_destroy()`.
+ * Real `Transaction` / `Database` / `NativeClient` objects are instantiated
+ * without running their constructors and wired to the stub via reflection, so
+ * the actual production destructor path is exercised end-to-end.
+ */
+final class TransactionSnapshotLifecycleTest extends TestCase
+{
+    private static ?FFI $stub = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$stub = self::buildStub();
+    }
+
+    // -- Tests -------------------------------------------------------------
+
+    #[Test]
+    public function snapshotReturnsFreshInstancePerCall(): void
+    {
+        $tx = self::makeTransaction();
+
+        $first = $tx->snapshot();
+        $second = $tx->snapshot();
+
+        // Fresh object every call: caching the Snapshot is what created the cycle.
+        self::assertNotSame($first, $second);
+
+        // Both share the parent's native handle, so reads stay consistent...
+        self::assertSame($tx->getPointer(), $first->getPointer());
+        self::assertSame($tx->getPointer(), $second->getPointer());
+
+        // ...and each Snapshot still anchors its parent transaction.
+        $parent = $this->parentOf($first);
+        self::assertSame($tx, $parent);
+    }
+
+    #[Test]
+    public function transactionHandleIsDestroyedOnScopeExitWithoutCycleCollector(): void
+    {
+        $before = $this->destroyCalls();
+
+        $scope = static function (): void {
+            $tx = self::makeTransaction();
+            // Snapshot anchors the Transaction one-directionally; the returned
+            // object is intentionally discarded here (that is the point of
+            // this scope-exit test), so the "no effect" result is expected.
+            /** @phpstan-ignore-next-line method.resultUnused */
+            $tx->snapshot();
+            // Both objects go out of scope here.
+        };
+
+        // With the old cyclic cache the destructor could not run here: the
+        // graph was only collectable by the cycle collector, so the counter
+        // would stay untouched and the Error-free return would fail the assert.
+        $scope();
+
+        self::assertSame(
+            $before + 1,
+            $this->destroyCalls(),
+            'fdb_transaction_destroy() must run exactly once when the '
+            . 'transaction + snapshot graph leaves scope with gc disabled',
+        );
+    }
+
+    #[Test]
+    public function repeatedSnapshotLoopsDoNotAccumulateNativeHandles(): void
+    {
+        $before = $this->destroyCalls();
+        $iterations = 25;
+
+        for ($i = 0; $i < $iterations; $i++) {
+            // Mirrors Database::readTransact() / HighContentionAllocator::
+            // allocate(): a short-lived transaction whose work goes through
+            // ->snapshot(). Each iteration is its own scope so both objects
+            // are released before the next one starts. The returned Snapshot
+            // is intentionally discarded (that is the point of this test).
+            /** @phpstan-ignore-next-line method.resultUnused */
+            self::makeTransaction()->snapshot();
+        }
+
+        self::assertSame(
+            $before + $iterations,
+            $this->destroyCalls(),
+            'every loop iteration must release its native transaction handle',
+        );
+    }
+
+    // -- Stub library ------------------------------------------------------
+
+    /**
+     * Compiles (once per machine) a minimal stand-in for libfdb_c.so exposing
+     * a counting fdb_transaction_destroy(), and binds it through FFI. Skips
+     * the test when no C compiler is available rather than failing CI images
+     * that legitimately ship without one.
+     */
+    private static function buildStub(): FFI
+    {
+        $source = <<<'C'
+            #include <stdint.h>
+            static int64_t g_destroy_calls = 0;
+            void fdb_transaction_destroy(void* tr) { (void)tr; g_destroy_calls += 1; }
+            int64_t fdb_phpunit_stub_destroy_calls(void) { return g_destroy_calls; }
+            void fdb_database_destroy(void* d) { (void)d; }
+            C;
+
+        $header = <<<'C'
+            typedef struct FDB_transaction { unsigned char _opaque; } FDB_transaction;
+            void fdb_transaction_destroy(FDB_transaction* tr);
+            int64_t fdb_phpunit_stub_destroy_calls(void);
+            void fdb_database_destroy(FDB_transaction* d);
+            C;
+
+        if (!extension_loaded('ffi')) {
+            self::markTestSkipped('ext-ffi is not available');
+        }
+
+        $cacheKey = md5($source . $header . PHP_VERSION . PHP_OS_FAMILY);
+        $libraryPath = sys_get_temp_dir() . '/fdb-php-phpunit-stub-' . $cacheKey . '.so';
+        $sourcePath = sys_get_temp_dir() . '/fdb-php-phpunit-stub-' . $cacheKey . '.c';
+
+        if (!is_file($libraryPath)) {
+            file_put_contents($sourcePath, $source);
+
+            $flags = PHP_OS_FAMILY === 'Darwin' ? '-dynamiclib' : '-shared';
+            $command = sprintf(
+                'cc %s -fPIC -o %s %s 2>&1',
+                $flags,
+                escapeshellarg($libraryPath),
+                escapeshellarg($sourcePath),
+            );
+            exec($command, $outputLines, $exitCode);
+
+            if ($exitCode !== 0) {
+                self::markTestSkipped(sprintf(
+                    'Cannot compile the FDB transaction stub (%s): %s',
+                    $command,
+                    implode("\n", $outputLines),
+                ));
+            }
+        }
+
+        try {
+            return FFI::cdef($header, $libraryPath);
+        } catch (\Throwable $e) {
+            self::markTestSkipped('Cannot load the FDB transaction stub: ' . $e->getMessage());
+        }
+    }
+
+    private function destroyCalls(): int
+    {
+        $stub = self::$stub;
+        \assert($stub instanceof FFI);
+
+        /** @phpstan-ignore-next-line method.notFound — dynamic FFI binding to the compiled stub */
+        return $stub->fdb_phpunit_stub_destroy_calls();
+    }
+
+    // -- Object wiring -----------------------------------------------------
+
+    /**
+     * Builds a real Transaction wired to the stub, bypassing constructors:
+     * NativeClient::__construct() loads the genuine libfdb_c and Database's
+     * constructor expects a native database handle. Only three read-only
+     * properties on ReadTransaction plus the two aggregate objects matter
+     * for the lifetime path under test.
+     */
+    private static function makeTransaction(): Transaction
+    {
+        $stub = self::$stub;
+        \assert($stub instanceof FFI);
+
+        $nativeClient = (new \ReflectionClass(NativeClient::class))->newInstanceWithoutConstructor();
+        self::initializeReadOnly($nativeClient, 'fdb', $stub);
+
+        $database = (new \ReflectionClass(Database::class))->newInstanceWithoutConstructor();
+        self::initializeReadOnly($database, 'dpointer', $stub->new('FDB_transaction*'));
+        self::initializeReadOnly($database, 'client', $nativeClient);
+
+        $transaction = (new \ReflectionClass(Transaction::class))->newInstanceWithoutConstructor();
+        // Production wires a pointer-typed handle (from
+        // fdb_database_create_transaction's out-parameter), so mirror that:
+        // FFI validates the CData kind when __destruct() calls into the stub.
+        self::initializeReadOnly($transaction, 'tpointer', $stub->new('FDB_transaction*'));
+        self::initializeReadOnly($transaction, 'db', $database);
+        self::initializeReadOnly($transaction, 'client', $nativeClient);
+
+        return $transaction;
+    }
+
+    /**
+     * Initializes a typed (possibly readonly) property without invoking the
+     * constructor. Uses a class-scope-bound closure, which initializes
+     * uninitialized readonly properties on every supported PHP version
+     * (8.2-8.4); falls back to reflection for forward compatibility.
+     */
+    private static function initializeReadOnly(object $object, string $property, mixed $value): void
+    {
+        try {
+            \Closure::bind(
+                static function (object $target, string $name, mixed $val): void {
+                    // Bound to the declaring scope: legal for readonly init.
+                    $that = $target;
+                    $that->$name = $val;
+                },
+                null,
+                $object,
+            )($object, $property, $value);
+
+            return;
+        } catch (\Throwable) {
+            // Fall through to the reflection path.
+        }
+
+        $reflection = new \ReflectionProperty($object, $property);
+        $reflection->setValue($object, $value);
+    }
+
+    private function parentOf(object $snapshot): Transaction
+    {
+        $reflection = new \ReflectionProperty($snapshot, 'parentTransaction');
+        $parent = $reflection->getValue($snapshot);
+        \assert($parent instanceof Transaction);
+
+        return $parent;
+    }
+}


### PR DESCRIPTION
Closes #38

## Problem
`Transaction::snapshot()` cached the Snapshot on the transaction while the
Snapshot held a strong back-reference to its parent, forming a reference
cycle (`Transaction -> snapshotInstance -> parentTransaction`). Because both
sides held strong references, the refcount never reached zero on scope exit,
so `fdb_transaction_destroy()` did not run deterministically - it was deferred
to the PHP cycle collector, and with `zend.enable_gc=0` until process
shutdown. Every `Database::readTransact()`, every directory create/open
(through HighContentionAllocator) and every Locality call created the cycle,
so long-running workers (FPM/RoadRunner/Swoole/queues) accumulated live native
transaction handles.

## Fix
`Transaction::snapshot()` now returns a fresh `Snapshot` each call instead of
caching one. Ownership is one-directional (the Snapshot keeps its parent alive,
not vice versa), read-only semantics are unchanged, and snapshots still share
the parent's native handle so reads remain consistent. Both objects are released
deterministically when they go out of scope.

## Coverage
- **Unit** (`tests/Unit/TransactionSnapshotLifecycleTest.php`): proves
  `fdb_transaction_destroy()` runs exactly once per scope exit even with the
  cycle collector out of the picture. A tiny native stub library with a
  counting `fdb_transaction_destroy()` is compiled on the fly, and real
  `Transaction`/`Database`/`NativeClient` objects are wired to it via
  reflection (no cluster required).
- **Integration** (`tests/Integration/TransactionSnapshotLifecycleTest.php`):
  a 200-iteration `readTransact()` loop against a live cluster stays healthy -
  the primary leak vector named in the issue.

## Verification
- `composer lint` OK (PHPCS + Rector dry-run + PHPStan level 9)
- `composer test:unit` OK (472 tests)
- `./vendor/bin/phpunit --testsuite=Integration --testdox` OK (210 tests, 710 assertions)
